### PR TITLE
Updating class/namespace references for latest Symfony2 release

### DIFF
--- a/DependencyInjection/RedisExtension.php
+++ b/DependencyInjection/RedisExtension.php
@@ -2,9 +2,9 @@
 
 namespace Bundle\RedisBundle\DependencyInjection;
 
-use Symfony\Components\DependencyInjection\Extension\Extension;
-use Symfony\Components\DependencyInjection\Loader\XmlFileLoader;
-use Symfony\Components\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\Extension;
+use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 class RedisExtension extends Extension
 {

--- a/RedisBundle.php
+++ b/RedisBundle.php
@@ -3,7 +3,7 @@
 namespace Bundle\RedisBundle;
 
 use Bundle\RedisBundle\DependencyInjection\RedisExtension;
-use Symfony\Framework\Bundle\Bundle;
+use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\Components\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Components\DependencyInjection\ContainerBuilder;
 


### PR DESCRIPTION
Components namespace was changed to Component
Location of core Bundle class has changed.
