### PR TITLE
PHP Notice from RedisExtension->load()

### DIFF
--- a/DependencyInjection/RedisExtension.php
+++ b/DependencyInjection/RedisExtension.php
@@ -44,7 +44,7 @@ class RedisExtension extends Extension
             $this->loadSession($config, $container, $loader);
         }
 
-        if (0 < count($config['doctrine'])) {
+        if (isset($config['doctrine']) && 0 < count($config['doctrine'])) {
             $this->loadDoctrine($config, $container);
         }
     }


### PR DESCRIPTION
Hi

the isset($config['doctrine']) in the RedisExtension->load() method throws a PHP Notice if the 'doctrine' setting is not set, I fixed that by checking if it is first.

regards

Stefan Paschke
