### PR TITLE
Parameters "password" and "database" has no effect

### DIFF
--- a/RedisClient.php
+++ b/RedisClient.php
@@ -4,6 +4,29 @@ namespace Snc\RedisBundle;
 
 class RedisClient extends \Predis\Client
 {
+    public function __construct($parameters = null, $options = null) {
+        parent::__construct($parameters, $options);
+
+        if($parameters instanceof IConnectionSingle)
+        {
+            $this->pushInitCommands($parameters);
+        }
+    }
+
+    private function pushInitCommands(IConnectionSingle $connection) {
+        $params = $connection->getParameters();
+        if (isset($params->password)) {
+            $connection->pushInitCommand($this->createCommand(
+                'auth', array($params->password)
+            ));
+        }
+        if (isset($params->database)) {
+            $connection->pushInitCommand($this->createCommand(
+                'select', array($params->database)
+            ));
+        }
+    }
+
     /**
      * Putting session_write_close() to fix bug caused by APC where object 
      * destruction occurs in the wrong order


### PR DESCRIPTION
I found  parameter "password" and "database" did not work in current version of RedisBundle.

In Predis\Client::__construct(), Predis\Client will check the argument "$parameters" to see if the argument is an instance of IConnection, if it's, Predis\Client::__construct() will not do the "pushInitCommands" operations but return the argument directly, as a result, parameters "password" and "database" will be completely ignored.

I had try to find a way to do the "pushInitCommands" operations somewhere, but because Predis\Client::pushInitCommands has a private access level, it can't not be called from outside of the class, so, I have to copy it from Predis\Client and paste it to Snc\RedisBundle\RedisClient to reuse it.

PS:
To make this work, you have to set the parameter "redis.class" to "Snc\RedisBundle\RedisClient" in the config.yml, like this:

  redis:
    class:
      client: Snc\RedisBundle\RedisClient
    connections:
      default:
        host:     localhost
        port:     6399
        database: 2
        logging: %kernel.debug%
        alias:    default
