### PR TITLE
Enable simple disabling of logging

### DIFF
--- a/Client/Predis/Network/LoggingStreamConnection.php
+++ b/Client/Predis/Network/LoggingStreamConnection.php
@@ -22,7 +22,7 @@ class LoggingStreamConnection extends StreamConnection
      *
      * @param RedisLogger $logger A RedisLogger instance
      */
-    public function setLogger(RedisLogger $logger)
+    public function setLogger(RedisLogger $logger = null)
     {
         $this->logger = $logger;
     }


### PR DESCRIPTION
In certain instances it can be usefull to disable logging.  One such example is in unit tests for some parts you may want the logger, for some parts you may want it disabled. Allowing for a default of null lets this happen.
