### PR TITLE
Add support for Composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "snc/redis-bundle",
-    "type": "library",
+    "type": "symfony-bundle",
     "description": "A Redis bundle for Symfony2",
     "keywords": ["redis", "nosql", "symfony"],
     "homepage": "http://github.com/snc/SncRedisBundle",


### PR DESCRIPTION
This PR adds the `composer.json` file to the root of the repository in order to support [Composer](http://packagist.org/about-composer), which aims to ease the management of dependencies for libraries and applications. Now this bundle can also be published on [Packagist](http://packagist.org/) since all the needed dependencies (such as Predis, Symfony2 and Doctrine) are already there.

You should bump the version number to `1.0.1`.
