### PR TITLE
Fix the name of the protected field that holds connection parameters.

### DIFF
--- a/Client/Predis/Network/LoggingStreamConnection.php
+++ b/Client/Predis/Network/LoggingStreamConnection.php
@@ -45,7 +45,7 @@ class LoggingStreamConnection extends StreamConnection
         $duration = (microtime(true) - $startTime) * 1000;
         if (null !== $this->logger) {
             $error = $result instanceof ResponseError ? (string) $result : false;
-            $this->logger->logCommand((string) $command, $duration, $this->_params->alias, $error);
+            $this->logger->logCommand((string) $command, $duration, $this->parameters->alias, $error);
         }
         return $result;
     }


### PR DESCRIPTION
This has been recently changed in Predis (sorry for that), we won't modify the names of public or protected fields anymore until v0.8.
