### PR TITLE
Client options

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -38,7 +38,7 @@ class Configuration implements ConfigurationInterface
                     ->addDefaultsIfNotSet()
                     ->children()
                         ->scalarNode('client')->defaultValue('Predis\Client')->end()
-                        ->scalarNode('client_options')->defaultValue('Predis\ClientOptions')->end()
+                        ->scalarNode('client_options')->defaultValue('Predis\Options\ClientOptions')->end()
                         ->scalarNode('connection_parameters')->defaultValue('Predis\ConnectionParameters')->end()
                         ->scalarNode('connection_factory')->defaultValue('Snc\RedisBundle\Client\Predis\ConnectionFactory')->end()
                         ->scalarNode('connection_wrapper')->defaultValue('Snc\RedisBundle\Client\Predis\Network\ConnectionWrapper')->end()

--- a/Tests/DependencyInjection/SncRedisExtensionTest.php
+++ b/Tests/DependencyInjection/SncRedisExtensionTest.php
@@ -23,7 +23,7 @@ class SncRedisExtensionTest extends \PHPUnit_Framework_TestCase
     {
         return array(
             array('snc_redis.client.class', 'Predis\Client'),
-            array('snc_redis.client_options.class', 'Predis\ClientOptions'),
+            array('snc_redis.client_options.class', 'Predis\Options\ClientOptions'),
             array('snc_redis.connection_parameters.class', 'Predis\ConnectionParameters'),
             array('snc_redis.connection_factory.class', 'Snc\RedisBundle\Client\Predis\ConnectionFactory'),
             array('snc_redis.connection_wrapper.class', 'Snc\RedisBundle\Client\Predis\Network\ConnectionWrapper'),


### PR DESCRIPTION
This change is needed since the `Predis\ClientOptions` class has been moved into the `Predis\Options` namespace.
