### PR TITLE
Unexpected Predis\ServerException in Doctrine\Common\Cache\Cache\RedisCache::deleteAll()

### DIFF
--- a/Doctrine/Cache/RedisCache.php
+++ b/Doctrine/Cache/RedisCache.php
@@ -125,8 +125,10 @@ class RedisCache implements Cache
     public function deleteAll()
     {
         $ids = $this->getIds();
-
-        $this->_doDelete($ids);
+        
+        if(count($ids) > 0) {
+            $this->_doDelete($ids);
+        }
 
         return $ids;
     }


### PR DESCRIPTION
Running app/console `doctrine:cache:clear-metadata` throws the following exception if cache is empty:

[Predis\ServerException]
ERR wrong number of arguments for 'del' command
