### PR TITLE
added config option "use_as_default" for session store

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -151,6 +151,7 @@ class Configuration implements ConfigurationInterface
                     ->children()
                         ->scalarNode('client')->isRequired()->end()
                         ->scalarNode('prefix')->defaultValue('session')->end()
+                        ->scalarNode('use_as_default')->defaultValue('true')->end()
                     ->end()
                 ->end()
             ->end();

--- a/DependencyInjection/SncRedisExtension.php
+++ b/DependencyInjection/SncRedisExtension.php
@@ -151,7 +151,10 @@ class SncRedisExtension extends Extension
         $container->setParameter('snc_redis.session.prefix', $config['session']['prefix']);
 
         $container->setAlias('snc_redis.session.client', sprintf('snc_redis.%s_client', $container->getParameter('snc_redis.session.client')));
-        $container->setAlias('session.storage', 'snc_redis.session.storage');
+
+        if ($config['session']['use_as_default']) {
+            $container->setAlias('session.storage', 'snc_redis.session.storage');
+        }
     }
 
     /**


### PR DESCRIPTION
added "use_as_default" parameter for session store to steer automatic registration (defaults to "true" to not break previous installs)
