### PR TITLE
Avoid creating PHP native sessions when using redis session storage

### DIFF
--- a/SessionStorage/RedisSessionStorage.php
+++ b/SessionStorage/RedisSessionStorage.php
@@ -18,8 +18,8 @@ use Predis\Client;
 /**
  * Redis based session storage
  *
- * @link    http://github.com/justinrainbow/
  * @author  Justin Rainbow <justin.rainbow@gmail.com>
+ * @author  Jordi Boggiano <j.boggiano@seld.be>
  */
 class RedisSessionStorage extends NativeSessionStorage
 {
@@ -47,21 +47,107 @@ class RedisSessionStorage extends NativeSessionStorage
     }
 
     /**
-     * Reads a session.
+     * Starts the session.
+     */
+    public function start()
+    {
+        if (self::$sessionStarted) {
+            return;
+        }
+
+        // use this object as the session handler
+        session_set_save_handler(
+            array($this, 'sessionOpen'),
+            array($this, 'sessionClose'),
+            array($this, 'sessionRead'),
+            array($this, 'sessionWrite'),
+            array($this, 'sessionDestroy'),
+            array($this, 'sessionGC')
+        );
+
+        parent::start();
+    }
+
+    /**
+     * Opens a session.
+     *
+     * @param  string $path  (ignored)
+     * @param  string $name  (ignored)
+     *
+     * @return Boolean true, if the session was opened, otherwise an exception is thrown
+     */
+    public function sessionOpen($path = null, $name = null)
+    {
+        return true;
+    }
+
+    /**
+     * Closes a session.
+     *
+     * @return Boolean true, if the session was closed, otherwise false
+     */
+    public function sessionClose()
+    {
+        return true;
+    }
+
+    /**
+     * Destroys a session.
      *
      * @param  string $id  A session ID
      *
-     * @return string      The session data if the session was read or created, otherwise an exception is thrown
-     *
-     * @throws \RuntimeException If the session cannot be read
+     * @return Boolean  true
      */
-    public function read($key, $default = null)
+    public function sessionDestroy($id)
     {
-        if (null !== ($data = $this->db->hget($this->getHashKey(), $key))) {
-            return @unserialize($data);
+        $this->db->del($this->getKey($id));
+
+        return true;
+    }
+
+    /**
+     * Cleans up old sessions.
+     *
+     * Dummy function since this is handled in write with EXPIRE
+     *
+     * @param  int $lifetime  The lifetime of a session
+     *
+     * @return Boolean true
+     */
+    public function sessionGC($lifetime)
+    {
+        return true;
+    }
+
+    /**
+     * Reads a session.
+     *
+     * @param  string $id  A session ID
+     * @return string The session data if the session was read or created
+     */
+    public function sessionRead($id)
+    {
+        try {
+            $data = $this->db->get($this->getKey($id));
+        } catch (\Predis\ServerException $e) {
+            $data = false;
         }
 
-        return $default;
+        // BC for older redis session handler if we get an invalid read, most likely it's a hash
+        if (false === $data) {
+            if ($data = $this->db->hgetall($this->getKey($id))) {
+                foreach ($data as $key => $val) {
+                    $_SESSION[$key] = @unserialize($val);
+                }
+                $data = session_encode();
+
+                // migrate data to new format
+                $this->db->del($this->getKey($id));
+                $this->sessionWrite($id, $data);
+            }
+        }
+
+        return (string) $data;
     }
 
     /**
@@ -69,57 +155,32 @@ class RedisSessionStorage extends NativeSessionStorage
      *
      * @param  string $id    A session ID
      * @param  string $data  A serialized chunk of session data
-     *
-     * @return bool true, if the session was written, otherwise an exception is thrown
-     *
-     * @throws \RuntimeException If the session data cannot be written
+     * @return Boolean whether the session was written
      */
-    public function write($key, $data)
+    public function sessionWrite($id, $data)
     {
-        $result = $this->db->hset($this->getHashKey(), $key, serialize($data));
+        $result = $this->db->set($this->getKey($id), $data);
 
         $expires = (int) $this->options['lifetime'];
-
         if ($expires > 0) {
-            $this->db->expire($this->getHashKey(), $expires);
+            $this->db->expire($this->getKey($id), $expires);
         }
 
         return $result;
     }
 
     /**
-     * Deletes the provided session key.
-     *
-     * @param  string $id   A session ID
-     *
-     * @return bool   true, if the session data was deleted
-     */
-    public function remove($key)
-    {
-        return $this->db->hdel($this->getHashKey(), $key);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function regenerate($destroy = false)
-    {
-        $this->db->del($this->getHashKey());
-
-        return parent::regenerate($destroy);
-    }
-
-    /**
      * Prepends the Session ID with a user-defined prefix (if any).
      *
+     * @param string $id session id
      * @return string prefixed session ID
      */
-    protected function getHashKey()
+    protected function getKey($id)
     {
         if (!isset($this->options['prefix'])) {
-            return $this->getId();
+            return $id;
         }
 
-        return $this->options['prefix'] . ':' . $this->getId();
+        return $this->options['prefix'] . ':' . $id;
     }
 }


### PR DESCRIPTION
Should be BC by migrating session data the first time an old-style session is read.
