### PR TITLE
Disconnect wrapped connections

### DIFF
--- a/Client/Predis/Network/ConnectionWrapper.php
+++ b/Client/Predis/Network/ConnectionWrapper.php
@@ -78,7 +78,7 @@ class ConnectionWrapper implements IConnectionSingle
      */
     public function disconnect()
     {
-        return $this->connection->connect();
+        return $this->connection->disconnect();
     }
 
     /**


### PR DESCRIPTION
This looks like a simple bug. I was getting 'already connected' exceptions until I made this change.
