### PR TITLE
predis should not be installed if user want to use phpredis.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+composer.lock
+composer.phar
+vendor

--- a/Tests/Doctrine/Cache/RedisCacheTest.php
+++ b/Tests/Doctrine/Cache/RedisCacheTest.php
@@ -20,9 +20,18 @@ class RedisCacheTest extends CacheTest
 
     public function setUp()
     {
+        $config = 'tcp://127.0.0.1:6379';
+
         if (class_exists('\Predis\Client')) {
-            $config = 'tcp://127.0.0.1:6379';
             $this->_redis = new \Predis\Client($config);
+        } elseif (class_exists('\Redis')) {
+            $this->_redis = new \Redis();
+            $this->_redis->connect($config);
+        } else {
+            $this->markTestSkipped(sprintf('The %s requires the predis library or phpredis extension.', __CLASS__));
+        }
+
+        if (null !== $this->_redis) {
             try {
                 $ok = $this->_redis->ping();
             } catch (\Exception $e) {
@@ -31,8 +40,6 @@ class RedisCacheTest extends CacheTest
             if (!$ok) {
                 $this->markTestSkipped(sprintf('The %s requires a redis instance listening on %s.', __CLASS__, $config));
             }
-        } else {
-            $this->markTestSkipped(sprintf('The %s requires the predis library.', __CLASS__));
         }
     }
 
@@ -40,6 +47,7 @@ class RedisCacheTest extends CacheTest
     {
         $driver = new RedisCache();
         $driver->setRedis($this->_redis);
+
         return $driver;
     }
 }

--- a/Tests/autoload.php.dist
+++ b/Tests/autoload.php.dist
@@ -1,5 +1,5 @@
 <?php
 
 $vendorDir = __DIR__ . '/../vendor';
-$loader = require $vendorDir . '/.composer/autoload.php';
+$loader = require $vendorDir . '/autoload.php';
 $loader->add('Doctrine\\Tests', $vendorDir . '/doctrine/common/tests');

--- a/composer.json
+++ b/composer.json
@@ -17,14 +17,15 @@
         "symfony/config": "2.0.*",
         "symfony/dependency-injection": "2.0.*",
         "symfony/framework-bundle": "2.0.*",
-        "symfony/yaml": "2.0.*",
-        "predis/predis": "0.7.*"
+        "symfony/yaml": "2.0.*"
     },
     "require-dev": {
-        "doctrine/common": "2.1.*"
+        "doctrine/common": "2.1.*",
+        "predis/predis": "0.7.*"
     },
     "suggest": {
-        "monolog/monolog": "If you want to use the monolog redis handler."
+        "monolog/monolog": "If you want to use the monolog redis handler.",
+        "predis/predis": "If you want to use predis"
     },
     "autoload": {
         "psr-0": { "Snc\\RedisBundle": "" }


### PR DESCRIPTION
- Update tests
- Add a gitignore for composer and vendor dir
- fix deprecated autoload during tests.
