### PR TITLE
Force `false` return for a cache miss

### DIFF
--- a/Doctrine/Cache/RedisCache.php
+++ b/Doctrine/Cache/RedisCache.php
@@ -52,7 +52,9 @@ class RedisCache extends CacheProvider
      */
     protected function doFetch($id)
     {
-        return $this->_redis->get($id);
+        $result = $this->_redis->get($id);
+
+        return null === $result ? false : $result;
     }
 
     /**


### PR DESCRIPTION
Now the `doFetch` method will return false instead of null when no entry exists.
