### PR TITLE
Fixed prefixing keys in Predis

### DIFF
--- a/DependencyInjection/SncRedisExtension.php
+++ b/DependencyInjection/SncRedisExtension.php
@@ -154,6 +154,13 @@ class SncRedisExtension extends Extension
         $profileDef = new Definition(get_class(\Predis\Profile\ServerProfile::get($client['options']['profile']))); // TODO get_class alternative?
         $profileDef->setPublic(false);
         $profileDef->setScope(ContainerInterface::SCOPE_CONTAINER);
+        if (null !== $client['options']['prefix']) {
+            $processorId = sprintf('snc_redis.client.%s_processor', $client['alias']);
+            $processorDef = new Definition('Predis\Command\Processor\KeyPrefixProcessor');
+            $processorDef->setArguments(array($client['options']['prefix']));
+            $container->setDefinition($processorId, $processorDef);
+            $profileDef->addMethodCall('setProcessor', array(new Reference($processorId)));
+        }
         $container->setDefinition($profileId, $profileDef);
         $client['options']['profile'] = new Reference($profileId);
 


### PR DESCRIPTION
As I understood, while reading the code of the Client, ClientOptions, ClientPrefix and ServerProfile classes - this -> https://gist.github.com/903421 <- code doesn't work.
Please correct me if I'm mistaken, but I couldn't get Predis prefixes working by just setting my client options.prefix in the bundle.
