### PR TITLE
Missing "s" in namespace causes erros

### DIFF
--- a/DependencyInjection/SncRedisExtension.php
+++ b/DependencyInjection/SncRedisExtension.php
@@ -151,7 +151,7 @@ class SncRedisExtension extends Extension
 
         // TODO can be shared between clients?!
         $profileId = sprintf('snc_redis.client.%s_profile', $client['alias']);
-        $profileDef = new Definition(get_class(\Predis\Profile\ServerProfile::get($client['options']['profile']))); // TODO get_class alternative?
+        $profileDef = new Definition(get_class(\Predis\Profiles\ServerProfile::get($client['options']['profile']))); // TODO get_class alternative?
         $profileDef->setPublic(false);
         $profileDef->setScope(ContainerInterface::SCOPE_CONTAINER);
         if (null !== $client['options']['prefix']) {


### PR DESCRIPTION
The missing "s" causes some errors while using this bundle.
