### PR TITLE
Can't use phpredis prefix.

### DIFF
--- a/DependencyInjection/SncRedisExtension.php
+++ b/DependencyInjection/SncRedisExtension.php
@@ -226,9 +226,6 @@ class SncRedisExtension extends Extension
         $phpredisDef = new Definition('Redis'); // TODO $container->getParameter('snc_redis.*.class')
         $phpredisDef->setPublic(true);
         $phpredisDef->setScope(ContainerInterface::SCOPE_CONTAINER);
-        if ($client['options']['prefix']) {
-            $phpredisDef->addMethodCall('setOption', array(\Redis::OPT_PREFIX, $client['options']['prefix']));
-        }
         $connectMethod = $client['options']['connection_persistent'] ? 'pconnect' : 'connect';
         $connectParameters = array();
         if (null !== $dsn->getSocket()) {
@@ -242,6 +239,9 @@ class SncRedisExtension extends Extension
             $connectParameters[] = $client['options']['connection_timeout'];
         }
         $phpredisDef->addMethodCall($connectMethod, $connectParameters);
+        if ($client['options']['prefix']) {
+            $phpredisDef->addMethodCall('setOption', array(\Redis::OPT_PREFIX, $client['options']['prefix']));
+        }
         if (null !== $dsn->getPassword()) {
             $phpredisDef->addMethodCall('auth', array($dsn->getPassword()));
         }


### PR DESCRIPTION
config.yml

``` yml
snc_redis:
    clients:
        default:
            dsn: "redis://localhost:6379"
            options:
                prefix : "prefix"
            type: phpredis
            alias: default
            logging: %kernel.debug%
```

This setting throws excection follows.

```
RedisException: Redis server went away
in /data/home/soichiro_yoshimura/workspace/trunk/Symfony/app/cache/neat_dev/appNeat_devDebugProjectContainer.php line 2513
at Redis->setOption('2', 'prefix') in /data/home/soichiro_yoshimura/workspace/trunk/Symfony/app/cache/neat_dev/appNeat_devDebugProjectContainer.php line 2513
at appNeat_devDebugProjectContainer->getSncRedis_DefaultService() in /data/home/soichiro_yoshimura/workspace/nicotter/Symfony/app/bootstrap.php.cache line 211
// ...
```

/data/home/soichiro_yoshimura/workspace/trunk/Symfony/app/cache/neat_dev/appNeat_devDebugProjectContainer.php line 2513

``` php
/**
 * Gets the 'snc_redis.default' service.
 *
 * This service is shared.
 * This method always returns the same instance of the service.
 *
 * @return Snc\RedisBundle\Client\Phpredis\Client A Snc\RedisBundle\Client\Phpredis\Client instance.
 */
protected function getSncRedis_DefaultService()
{
    $a = new \Redis();
    $a->setOption(2, 'prefix');
    $a->connect('localhost', 6379, 2);
    $a->select(0);

    $this->services['snc_redis.default'] = $instance = new \Snc\RedisBundle\Client\Phpredis\Client(array('alias' => 'default'), $this->get('snc_redis.logger'));

    $instance->setRedis($a);

    return $instance;
}
```

Please fix to move "setOption" after "connect". and test phpredis prefix options.
