### PR TITLE
Update index.md

### DIFF
--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -238,7 +238,15 @@ snc_redis:
         key: swiftmailer
 ```
 
-Please note that you don't have to configure the `swiftmailer.spool` property.
+Please note you have to configure your Swiftmailer spool in order to Pickup the RedisSpool
+
+``` yaml
+swiftmailer:
+    # Rest of your swiftmailer configuration
+    spool:
+        type: Snc\RedisBundle\SwiftMailer\RedisSpool
+```
+
 
 ### Complete configuration example ###
 


### PR DESCRIPTION
Hi I think the documentation on how to use swiftmailer with this bundle is a bit miss leading. I tried do configure swiftmailer to use snc_redis mail spool and store emails instead of sending them out via memory spool.

My snc_redis config looks like this:

``` yaml
snc_redis:
  clients:
    default:
      type: predis
      alias: default
      dsn: %redis_dsn%
      logging: %kernel.debug%
    session:
      type: predis
      alias: session
      dsn: redis://%session_redis_host%:%session_redis_port%/2
  swiftmailer:
      client: session
      key: swiftmailer
  session:
    ttl: %session_redis_expire%
    client: session
    prefix: %session_redis_prefix%
    use_as_default: true
```

My Swiftmailer configuration looked like this:

``` yaml
swiftmailer:
    transport: %mailer_transport%
    host:      %mailer_host%
```

But in order to store mails into redis I hat to extend the spool.type configuration with the RedisSpool mailer implementation. This solved my problem that swiftmailer used memory spool and directly send out the mails.

``` yaml
swiftmailer:
    transport: %mailer_transport%
    host:      %mailer_host%
    spool:
        type: Snc\RedisBundle\SwiftMailer\RedisSpool
```

And this is the complete oposite of:

> Please note that you don't have to configure the `swiftmailer.spool` property.
