### PR TITLE
Using travis way of installing dependencies with composer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,6 @@ php:
   - 5.3
   - 5.4
 
-before_script: sh Tests/bootstrap.sh
+before_script:
+  - composer install --dev
+  - mkdir Snc && ln -s ../ Snc/RedisBundle

--- a/Tests/bootstrap.sh
+++ b/Tests/bootstrap.sh
@@ -1,8 +1,0 @@
-#!/bin/sh
-wget --quiet http://getcomposer.org/composer.phar && \
-
-# see https://github.com/composer/composer/issues/640
-sed -i -e 's#"symfony/dependency-injection": "2.0.*",#"symfony/dependency-injection": "2.0.*", "doctrine/common": "2.1.*",#' composer.json
-
-php composer.phar install --dev && \
-mkdir Snc && ln -s ../ Snc/RedisBundle


### PR DESCRIPTION
Travis php boxes now ship with build-in composer, so there is no need to download it.

You also had some legacy code in there to make sure `install --dev` works properly. This is not needed anymore due to some changes by composer (see https://github.com/composer/composer/issues/640).

This PR should be save to be merged into master also.
