### PR TITLE
Invalid Argument Exception thrown when configuring Monolog to use Redis according to documentation.

### DIFF
--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -217,7 +217,7 @@ monolog:
     handlers:
         main:
             type: service
-            id: monolog.handler.redis
+            id: snc_redis.logger
             level: debug
 ```
 


### PR DESCRIPTION
When I follow the directions to configure monolog to write to redis I receive the following error:

> [Symfony\Component\DependencyInjection\Exception\InvalidArgumentException] An alias can not reference itself, got a circular reference on "monolog.handler.redis".

Changing the handler service id from **monolog.handler.redis** to **snc_redis.logger** resolved the issue.  I will also note that I needed to change the dsn in snc_redis clients from **dsn: redis://localhost/1** to **dsn: redis://localhost** (not included in this patch). 
