### PR TITLE
Add "replication" option

### DIFF
--- a/DependencyInjection/Configuration/Configuration.php
+++ b/DependencyInjection/Configuration/Configuration.php
@@ -125,6 +125,7 @@ class Configuration implements ConfigurationInterface
                                     ->end()
                                     ->scalarNode('cluster')->defaultNull()->end()
                                     ->scalarNode('prefix')->defaultNull()->end()
+                                    ->booleanNode('replication')->defaultFalse()->end()
                                 ->end()
                             ->end()
                         ->end()

--- a/DependencyInjection/Configuration/RedisDsn.php
+++ b/DependencyInjection/Configuration/RedisDsn.php
@@ -52,6 +52,11 @@ class RedisDsn
     protected $weight;
 
     /**
+     * @var string
+     */
+    protected $alias;
+
+    /**
      * Constructor
      *
      * @param string $dsn
@@ -115,6 +120,14 @@ class RedisDsn
     }
 
     /**
+     * @return string
+     */
+    public function getAlias()
+    {
+        return $this->alias;
+    }
+
+    /**
      * @return bool
      */
     public function isValid()
@@ -145,7 +158,7 @@ class RedisDsn
             $this->password = str_replace('\@', '@', substr($dsn, 0, $pos));
             $dsn = substr($dsn, $pos + 1);
         }
-        $dsn = preg_replace_callback('/\?(weight)=[^&]+.*$/', array($this, 'parseParameters'), $dsn); // parse parameters
+        $dsn = preg_replace_callback('/\?(weight|alias)=[^&]+.*$/', array($this, 'parseParameters'), $dsn); // parse parameters
         if (preg_match('#^(.*)/(\d+)$#', $dsn, $matches)) {
             // parse database
             $this->database = (int) $matches[2];
@@ -182,6 +195,11 @@ class RedisDsn
                     case 'weight':
                         if ($kv[1]) {
                             $this->weight = (int) $kv[1];
+                        }
+                        break;
+                    case 'alias':
+                        if ($kv[1]) {
+                            $this->alias = $kv[1];
                         }
                         break;
                 }

--- a/DependencyInjection/SncRedisExtension.php
+++ b/DependencyInjection/SncRedisExtension.php
@@ -130,7 +130,9 @@ class SncRedisExtension extends Extension
         $connectionCount = count($client['dsns']);
         foreach ($client['dsns'] as $i => $dsn) {
             /** @var \Snc\RedisBundle\DependencyInjection\Configuration\RedisDsn $dsn */
-            $connectionAlias = 1 === $connectionCount ? $client['alias'] : $client['alias'] . ($i + 1);
+            if (!$connectionAlias = $dsn->getAlias()) {
+                $connectionAlias = 1 === $connectionCount ? $client['alias'] : $client['alias'] . ($i + 1);
+            }
             $connectionAliases[] = $connectionAlias;
             $connection = $client['options'];
             $connection['logging'] = $client['logging'];

--- a/Resources/config/schema/redis-1.0.xsd
+++ b/Resources/config/schema/redis-1.0.xsd
@@ -58,6 +58,7 @@
         <xsd:attribute name="profile" type="client-profile" />
         <xsd:attribute name="cluster" type="xsd:string" />
         <xsd:attribute name="prefix" type="xsd:string" />
+        <xsd:attribute name="replication" type="xsd:boolean" />
     </xsd:complexType>
 
     <xsd:simpleType name="client-profile">

--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -93,6 +93,26 @@ $val = $redis_cluster->get('ef:gh');
 $val = $redis_cluster->get('ij:kl');
 ```
 
+A setup using `predis` master-slave replication could look like this:
+
+``` yaml
+snc_redis:
+    clients:
+        default:
+            type: predis
+            alias: default
+            dsn:
+                - redis://master-host?alias=master
+                - redis://slave-host1
+                - redis://slave-host2
+            options:
+                replication: true
+```
+
+Please note that the master dsn connection needs to be tagged with the ```master``` alias.
+If not, `predis` will complain.
+
+
 ### Sessions ###
 
 Use Redis sessions by adding the following to your config:
@@ -248,6 +268,7 @@ snc_redis:
                 iterable_multibulk: false
                 throw_errors: true
                 cluster: Snc\RedisBundle\Client\Predis\Connection\PredisCluster
+                replication: false
     session:
         client: default
         prefix: foo

--- a/Tests/DependencyInjection/Configuration/RedisDsnTest.php
+++ b/Tests/DependencyInjection/Configuration/RedisDsnTest.php
@@ -242,31 +242,34 @@ class RedisDsnTest extends \PHPUnit_Framework_TestCase
      *
      * @return array
      */
-    public static function weightValues()
+    public static function parameterValues()
     {
         return array(
-            array('redis://localhost', null),
-            array('redis://localhost/1?weight=1', 1),
-            array('redis://pw@localhost:63790/10?weight=2', 2),
-            array('redis://127.0.0.1?weight=3', 3),
-            array('redis://127.0.0.1/1?weight=4', 4),
-            array('redis://pw@127.0.0.1:63790/10?weight=5', 5),
-            array('redis:///redis.sock?weight=6', 6),
-            array('redis:///redis.sock/1?weight=7', 7),
-            array('redis://pw@/redis.sock/10?weight=8', 8),
-            array('redis://pw@/redis.sock/10?weight=9', 9),
+            array('redis://localhost', null, null),
+            array('redis://localhost/1?weight=1&alias=master', 1, 'master'),
+            array('redis://pw@localhost:63790/10?alias=master&weight=2', 2, 'master'),
+            array('redis://127.0.0.1?weight=3', 3, null),
+            array('redis://127.0.0.1/1?alias=master&weight=4', 4, 'master'),
+            array('redis://pw@127.0.0.1:63790/10?weight=5&alias=master', 5, 'master'),
+            array('redis:///redis.sock?weight=6&alias=master', 6, 'master'),
+            array('redis:///redis.sock/1?weight=7', 7, null),
+            array('redis://pw@/redis.sock/10?weight=8&alias=master', 8, 'master'),
+            array('redis://pw@/redis.sock/10?alias=master&weight=9', 9, 'master'),
+            array('redis://localhost?alias=master', null, 'master'),
         );
     }
 
     /**
      * @param string $dsn    DSN
      * @param int    $weight Weight
+     * @param string $alias  Alias
      *
-     * @dataProvider weightValues
+     * @dataProvider parameterValues
      */
-    public function testParameterValues($dsn, $weight)
+    public function testParameterValues($dsn, $weight, $alias)
     {
         $dsn = new RedisDsn($dsn);
         $this->assertSame($weight, $dsn->getWeight());
+        $this->assertSame($alias, $dsn->getAlias());
     }
 }


### PR DESCRIPTION
The Predis library supports a MasterSlaveConnection through the use of the "replication" option. This PR adds this functionality to the bundle.

Also note that I have also added the possibility to change the alias per dsn, as the MasterSlaveConnection needs that the master alias to be "master" and not "alias1" as per the current behaviour of adding 1 to the connection alias.
