### PR TITLE
Monolog logging redis level doesn't work

### DIFF
--- a/DependencyInjection/Compiler/MonologPass.php
+++ b/DependencyInjection/Compiler/MonologPass.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the SncRedisBundle package.
+ *
+ * (c) Henrik Westphal <henrik.westphal@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Snc\RedisBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\Config\Definition\Processor;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class MonologPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $serviceId = 'snc_redis.monolog.handler';
+        if ($container->hasDefinition($serviceId)) {
+            $handlerDefinition = $container->getDefinition($serviceId);
+            $configuration = $container->getExtension('monolog')->getConfiguration(array(), $container);
+            $processor = new Processor();
+            $config = $processor->processConfiguration($configuration, $container->getExtensionConfig('monolog'));
+            foreach ($config['handlers'] as $handler) {
+                if (isset($handler['id']) && $serviceId === $handler['id']) {
+                    if (isset($handler['level'])) {
+                        $level = $handler['level'] = is_int($handler['level']) ? $handler['level'] : constant('Monolog\Logger::'.strtoupper($handler['level']));
+                        $handlerDefinition->addArgument($level);
+                    }
+                    if (isset($handler['bubble'])) {
+                        $handlerDefinition->addArgument($handler['bubble']);
+                    }
+
+                    return;
+                }
+            }
+        }
+    }
+}

--- a/SncRedisBundle.php
+++ b/SncRedisBundle.php
@@ -12,6 +12,7 @@
 namespace Snc\RedisBundle;
 
 use Snc\RedisBundle\DependencyInjection\Compiler\LoggingPass;
+use Snc\RedisBundle\DependencyInjection\Compiler\MonologPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -27,5 +28,6 @@ class SncRedisBundle extends Bundle
     {
         parent::build($container);
         $container->addCompilerPass(new LoggingPass());
+        $container->addCompilerPass(new MonologPass());
     }
 }


### PR DESCRIPTION
When I view the logger's output in redis, I see all level

``` yaml
monolog:
    handlers:
        main:
            type: service
            id: monolog.handler.redis
            level: error
```
