### PR TITLE
use parameters for phpredis classes

### DIFF
--- a/DependencyInjection/Configuration/Configuration.php
+++ b/DependencyInjection/Configuration/Configuration.php
@@ -42,6 +42,8 @@ class Configuration implements ConfigurationInterface
                         ->scalarNode('connection_parameters')->defaultValue('Predis\Connection\ConnectionParameters')->end()
                         ->scalarNode('connection_factory')->defaultValue('Snc\RedisBundle\Client\Predis\Connection\ConnectionFactory')->end()
                         ->scalarNode('connection_wrapper')->defaultValue('Snc\RedisBundle\Client\Predis\Connection\ConnectionWrapper')->end()
+                        ->scalarNode('phpredis_client')->defaultValue('Redis')->end()
+                        ->scalarNode('phpredis_connection_wrapper')->defaultValue('Snc\RedisBundle\Client\Phpredis\Client')->end()
                         ->scalarNode('logger')->defaultValue('Snc\RedisBundle\Logger\RedisLogger')->end()
                         ->scalarNode('data_collector')->defaultValue('Snc\RedisBundle\DataCollector\RedisDataCollector')->end()
                         ->scalarNode('doctrine_cache')->defaultValue('Snc\RedisBundle\Doctrine\Cache\RedisCache')->end()

--- a/DependencyInjection/SncRedisExtension.php
+++ b/DependencyInjection/SncRedisExtension.php
@@ -227,7 +227,7 @@ class SncRedisExtension extends Extension
         $dsn = $client['dsns'][0]; /** @var \Snc\RedisBundle\DependencyInjection\Configuration\RedisDsn $dsn */
 
         $phpredisId = sprintf('snc_redis.phpredis.%s', $client['alias']);
-        $phpredisDef = new Definition('Redis'); // TODO $container->getParameter('snc_redis.*.class')
+        $phpredisDef = new Definition($container->getParameter('snc_redis.phpredis_client.class'));
         $phpredisDef->setPublic(true);
         $phpredisDef->setScope(ContainerInterface::SCOPE_CONTAINER);
         $connectMethod = $client['options']['connection_persistent'] ? 'pconnect' : 'connect';
@@ -257,7 +257,7 @@ class SncRedisExtension extends Extension
         if ($client['logging']) {
             $phpredisDef->setPublic(false);
             $parameters = array('alias' => $client['alias']);
-            $clientDef = new Definition('Snc\RedisBundle\Client\Phpredis\Client'); // TODO $container->getParameter('snc_redis.*.class')
+            $clientDef = new Definition($container->getParameter('snc_redis.phpredis_connection_wrapper.class'));
             $clientDef->setScope(ContainerInterface::SCOPE_CONTAINER);
             $clientDef->addArgument($parameters);
             $clientDef->addArgument(new Reference('snc_redis.logger'));


### PR DESCRIPTION
It's now possible to override PhpRedis Client et ConnectionWrapper with parameters.
