### PR TITLE
Force the fact the RedisLogger not be instantiated...

### DIFF
--- a/DependencyInjection/Configuration/Configuration.php
+++ b/DependencyInjection/Configuration/Configuration.php
@@ -118,6 +118,7 @@ class Configuration implements ConfigurationInterface
                                     ->scalarNode('connection_timeout')->defaultValue(5)->end()
                                     ->scalarNode('read_write_timeout')->defaultNull()->end()
                                     ->booleanNode('iterable_multibulk')->defaultFalse()->end()
+                                    ->booleanNode('disable_logger')->defaultFalse()->end()
                                     ->booleanNode('throw_errors')->defaultTrue()->end()
                                     ->scalarNode('profile')->defaultValue('2.4')
                                         ->beforeNormalization()

--- a/DependencyInjection/SncRedisExtension.php
+++ b/DependencyInjection/SncRedisExtension.php
@@ -260,7 +260,10 @@ class SncRedisExtension extends Extension
             $clientDef = new Definition($container->getParameter('snc_redis.phpredis_connection_wrapper.class'));
             $clientDef->setScope(ContainerInterface::SCOPE_CONTAINER);
             $clientDef->addArgument($parameters);
-            $clientDef->addArgument(new Reference('snc_redis.logger'));
+
+            if (false === $client['options']['disable_logger']) {
+                $clientDef->addArgument(new Reference('snc_redis.logger'));
+            }
             $clientDef->addMethodCall('setRedis', array(new Reference($phpredisId)));
             $container->setDefinition(sprintf('snc_redis.%s', $client['alias']), $clientDef);
         } else {


### PR DESCRIPTION
...Otherwise a memory leak appears on batch tasks.

Given the second parameter of the constructor in the Snc\RedisBundle\Client\Phpredis\Client.php file is null by default, it should not be instanciated when it is not needed.
