### PR TITLE
Fixed travis-ci testsuite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,11 @@ php:
   - 5.3
   - 5.4
   - 5.5
+  - hhvm
+
+matrix:
+  allow_failures:
+    - php: hhvm
 
 before_script:
   - composer install --dev


### PR DESCRIPTION
php redis is now installed by default in travis-ci php.
