### PR TITLE
Client node not required by default

### DIFF
--- a/DependencyInjection/Configuration/Configuration.php
+++ b/DependencyInjection/Configuration/Configuration.php
@@ -80,7 +80,6 @@ class Configuration implements ConfigurationInterface
             ->fixXmlConfig('client')
             ->children()
                 ->arrayNode('clients')
-                    ->isRequired()
                     ->requiresAtLeastOneElement()
                     ->useAttributeAsKey('alias', false)
                     ->prototype('array')

--- a/Tests/DependencyInjection/SncRedisExtensionTest.php
+++ b/Tests/DependencyInjection/SncRedisExtensionTest.php
@@ -48,9 +48,6 @@ class SncRedisExtensionTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    /**
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     */
     public function testEmptyConfigLoad()
     {
         $extension = new SncRedisExtension();


### PR DESCRIPTION
Hi!
Sometimes (especially working with different 'environments') is useful disable redis bundle (via config.yml) but currently not possible.
