### PR TITLE
session expiration time should be based on session.gc_maxlifetime value ...

### DIFF
--- a/Session/Storage/Handler/RedisSessionHandler.php
+++ b/Session/Storage/Handler/RedisSessionHandler.php
@@ -77,7 +77,10 @@ class RedisSessionHandler implements \SessionHandlerInterface
     public function __construct($redis, array $options = array(), $prefix = 'session', $locking = true, $spinLockWait = 150000)
     {
         $this->redis = $redis;
-        $this->ttl = isset($options['cookie_lifetime']) ? (int) $options['cookie_lifetime'] : 0;
+        $this->ttl = isset($options['gc_maxlifetime']) ? (int) $options['gc_maxlifetime'] : 0; 
+        if (isset($options['cookie_lifetime']) && $options['cookie_lifetime'] > $this->ttl) {
+            $this->ttl = (int) $options['cookie_lifetime'];
+        }
         $this->prefix = $prefix;
 
         $this->locking = $locking;


### PR DESCRIPTION
session expiration time should be based on session.gc_maxlifetime value, and only in case session.cookie_lifetime is larger - on session.cookie_lifetime

otherwise, in case session.cookie_lifetime=0 (cookie lifetime limited to browser session lifetime), session is saved as permanent in redis and will never expire
