### PR TITLE
persistent connections - use a different persistent_id per DSN

### DIFF
--- a/DependencyInjection/Configuration/RedisDsn.php
+++ b/DependencyInjection/Configuration/RedisDsn.php
@@ -128,6 +128,14 @@ class RedisDsn
     }
 
     /**
+     * @return string
+     */
+    public function getPersistentId()
+    {
+        return sha1($this->dsn);
+    }
+
+    /**
      * @return bool
      */
     public function isValid()

--- a/DependencyInjection/SncRedisExtension.php
+++ b/DependencyInjection/SncRedisExtension.php
@@ -241,7 +241,13 @@ class SncRedisExtension extends Extension
         }
         if ($client['options']['connection_timeout']) {
             $connectParameters[] = $client['options']['connection_timeout'];
+        } else {
+            $connectParameters[] = 0;
         }
+        if ($client['options']['connection_persistent']) {
+            $connectParameters[] = $dsn->getPersistentId();
+        }
+
         $phpredisDef->addMethodCall($connectMethod, $connectParameters);
         if ($client['options']['prefix']) {
             $phpredisDef->addMethodCall('setOption', array(\Redis::OPT_PREFIX, $client['options']['prefix']));


### PR DESCRIPTION
When using persistent connections with different clients using the same redis server but different databases, the call to 'select' will only be issued during the client's construction, and it will happen on the same persistent connection. You'll end up working on the last opened client's database.

To fix this, I propose to use the persistent_id that can be given to pconnect (https://github.com/nicolasff/phpredis#pconnect-popen) and to tie the persistent connection to the full dsn (using an sha1 of the DSN).
