### PR TITLE
mark some tests as skipped if extension is not present

### DIFF
--- a/Tests/CommandTestCase.php
+++ b/Tests/CommandTestCase.php
@@ -46,6 +46,10 @@ abstract class CommandTestCase extends \PHPUnit_Framework_TestCase
      */
     public function setUp()
     {
+        if (!extension_loaded('redis')) {
+            $this->markTestSkipped('This test needs the PHP Redis extension to work');
+        }
+
         $kernel = $this->getMockBuilder('\\Symfony\\Component\\HttpKernel\\Kernel')
             ->disableOriginalConstructor()
             ->getMock();


### PR DESCRIPTION
Not a big deal, just to prevent failures in tests when extension is not loaded