### PR TITLE
Incorrect prefix using during lock/unlock operation

### DIFF
--- a/Session/Storage/Handler/RedisSessionHandler.php
+++ b/Session/Storage/Handler/RedisSessionHandler.php
@@ -108,10 +108,10 @@ class RedisSessionHandler implements \SessionHandlerInterface
 
         $this->lockKey = $sessionId.'.lock';
         for ($i=0;$i<$attempts;$i++) {
-            $success = $this->redis->setnx($this->prefix.$this->lockKey, '1');
+            $success = $this->redis->setnx($this->getRedisKey($this->lockKey), '1');
             if ($success) {
                 $this->locked = true;
-                $this->redis->expire($this->prefix.$this->lockKey, $this->lockMaxWait + 1);
+                $this->redis->expire($this->getRedisKey($this->lockKey), $this->lockMaxWait + 1);
                 return true;
             }
             usleep($this->spinLockWait);
@@ -122,7 +122,7 @@ class RedisSessionHandler implements \SessionHandlerInterface
 
     private function unlockSession()
     {
-        $this->redis->del($this->prefix.$this->lockKey);
+        $this->redis->del($this->getRedisKey($this->lockKey));
         $this->locked = false;
     }
 

--- a/Tests/Session/Storage/Handler/RedisSessionHandlerTest.php
+++ b/Tests/Session/Storage/Handler/RedisSessionHandlerTest.php
@@ -97,7 +97,7 @@ class RedisSessionHandlerTest extends \PHPUnit_Framework_TestCase
         $this->redis
             ->expects($this->exactly($lockMaxWait))
             ->method('setnx')
-            ->with($this->equalTo('session_symfony.lock'), $this->equalTo('1'))
+            ->with($this->equalTo('session:_symfony.lock'), $this->equalTo('1'))
         ;
 
         $handler = new RedisSessionHandler($this->redis, array(), 'session', true, 1000000);


### PR DESCRIPTION
Everything is actually working, but in logs we can see confusing LOCK records to "PrefixKey", and SET records to "Prefix:Key", and, if we have getRedisKey function - let's use it.