### PR TITLE
doc update, the bundle should be registered last

### DIFF
--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -18,7 +18,7 @@ If you want to use the `predis` client library, you have to add the `predis/pred
 $ composer require predis/predis 0.8.x-dev
 ```
 
-Add the RedisBundle to your application's kernel:
+Add the RedisBundle at the end of your application's kernel:
 
 ``` php
 <?php
@@ -27,11 +27,11 @@ public function registerBundles()
     $bundles = array(
         // ...
         new Snc\RedisBundle\SncRedisBundle(),
-        // ...
     );
     ...
 }
 ```
+Notice : since SncRedisBundle override some service aliases in the container, make sure that you register your bundle at the end in your application's kernel file.
 
 ## Usage ##
 


### PR DESCRIPTION
Maybe it should be specified that the bundle should be registered at the end of your appkernel file since we override some services aliases provided in symfony framework bundle.
Actually I spend one hour figuring out why the bundle wouldn't work because of that mistake ^^