### PR TITLE
Fixes session storage for HHVM (and possibly strict PHP environments)

### DIFF
--- a/Session/Storage/Handler/RedisSessionHandler.php
+++ b/Session/Storage/Handler/RedisSessionHandler.php
@@ -77,7 +77,7 @@ class RedisSessionHandler implements \SessionHandlerInterface
     public function __construct($redis, array $options = array(), $prefix = 'session', $locking = true, $spinLockWait = 150000)
     {
         $this->redis = $redis;
-        $this->ttl = isset($options['gc_maxlifetime']) ? (int) $options['gc_maxlifetime'] : 0; 
+        $this->ttl = isset($options['gc_maxlifetime']) ? (int) $options['gc_maxlifetime'] : 0;
         if (isset($options['cookie_lifetime']) && $options['cookie_lifetime'] > $this->ttl) {
             $this->ttl = (int) $options['cookie_lifetime'];
         }
@@ -165,6 +165,8 @@ class RedisSessionHandler implements \SessionHandlerInterface
         } else {
             $this->redis->set($this->getRedisKey($sessionId), $data);
         }
+
+        return true;
     }
 
     /**


### PR DESCRIPTION
The [SessionHandlerInterface](http://php.net/manual/en/class.sessionhandlerinterface.php) expects boolean return values for all methods (except read). This must've been an oversight when implementing this interface.

Unfortunately, in HHVM, this produces this (extremely unhelpful) error:

```
Warning: Failed to write session data (user). Please verify that the current setting of session.save_path is correct (unix:///var/run/redis/redis.sock) in ...
```

Quick and easy win!