### PR TITLE
if connection was not initialized it will throw exception on destruct

### DIFF
--- a/Client/Phpredis/BaseClient.php
+++ b/Client/Phpredis/BaseClient.php
@@ -58,7 +58,11 @@ class BaseClient implements ClientInterface
     public function __destruct()
     {
         if (null !== $this->redis) {
-            $this->redis->close();
+            try {
+                $this->redis->close();
+            } catch (\RedisException $ex) {
+                // if connection was not initialized it will throw exception when trying to close it
+            }
         }
     }
 }


### PR DESCRIPTION
if connection to redis is not initialize there will be exception on object

following code
```PHP
require_once 'vendor/autoload.php';
use Snc\RedisBundle\Client\Phpredis\Client;


$redis = new \Redis();
$client = new Client(['alias' => 'cache']);
$client->setRedis($redis);

// do nothing and exit

```
will throw exception:
```
PHP Fatal error:  Uncaught exception 'RedisException' with message 'Redis server went away' in ./vendor/snc/redis-bundle/Snc/RedisBundle/Client/Phpredis/BaseClient.php:61
Stack trace:
#0 ./vendor/snc/redis-bundle/Snc/RedisBundle/Client/Phpredis/BaseClient.php(61): Redis->close()
#1 [internal function]: Snc\RedisBundle\Client\Phpredis\BaseClient->__destruct()
#2 {main}
  thrown in ./vendor/snc/redis-bundle/Snc/RedisBundle/Client/Phpredis/BaseClient.php on line 61
```

This happens for example on build servers, where redis server is not running - "composer install" will trigger "app/console cache:clear" and it will fail with exception. 