### PR TITLE
Update RedisCache.php

### DIFF
--- a/Doctrine/Cache/RedisCache.php
+++ b/Doctrine/Cache/RedisCache.php
@@ -54,7 +54,7 @@ class RedisCache extends CacheProvider
     {
         $result = $this->_redis->get($id);
 
-        return null === $result ? false : unserialize($result);
+        return false === $result ? false : unserialize($result);
     }
 
     /**


### PR DESCRIPTION
'get' returns ``false`` not ``null``.
```
    /**
     * Get the value related to the specified key
     *
     * @param   string  $key
     * @return  string|bool: If key didn't exist, FALSE is returned. Otherwise, the value related to this key is returned.
     * @link    http://redis.io/commands/get
     * @example $redis->get('key');
     */
    public function get( $key ) {}
```