### PR TITLE
Fix multiple connections with same alias overwriting other connections parameters

### DIFF
--- a/DependencyInjection/SncRedisExtension.php
+++ b/DependencyInjection/SncRedisExtension.php
@@ -177,11 +177,11 @@ class SncRedisExtension extends Extension
         $clientDef = new Definition($container->getParameter('snc_redis.client.class'));
         $clientDef->setScope(ContainerInterface::SCOPE_CONTAINER);
         if (1 === $connectionCount) {
-            $clientDef->addArgument(new Reference(sprintf('snc_redis.connection.%s_parameters', $connectionAliases[0])));
+            $clientDef->addArgument(new Reference(sprintf('snc_redis.connection.%s_%s_parameters', $client['alias'], $connectionAliases[0])));
         } else {
             $connections = array();
             foreach ($connectionAliases as $alias) {
-                $connections[] = new Reference(sprintf('snc_redis.connection.%s_parameters', $alias));
+                $connections[] = new Reference(sprintf('snc_redis.connection.%s_%s_parameters', $client['alias'], $alias));
             }
             $clientDef->addArgument($connections);
         }
@@ -199,7 +199,7 @@ class SncRedisExtension extends Extension
      */
     protected function loadPredisConnectionParameters($clientAlias, array $connection, ContainerBuilder $container)
     {
-        $parameterId = sprintf('snc_redis.connection.%s_parameters', $connection['alias']);
+        $parameterId = sprintf('snc_redis.connection.%s_%s_parameters', $clientAlias, $connection['alias']);
         $parameterDef = new Definition($container->getParameter('snc_redis.connection_parameters.class'));
         $parameterDef->setPublic(false);
         $parameterDef->setScope(ContainerInterface::SCOPE_CONTAINER);

--- a/Tests/DependencyInjection/SncRedisExtensionTest.php
+++ b/Tests/DependencyInjection/SncRedisExtensionTest.php
@@ -85,7 +85,7 @@ class SncRedisExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($container->hasDefinition('snc_redis.logger'));
         $this->assertTrue($container->hasDefinition('snc_redis.data_collector'));
 
-        $this->assertTrue($container->hasDefinition('snc_redis.connection.default_parameters'));
+        $this->assertTrue($container->hasDefinition('snc_redis.connection.default_default_parameters'));
         $this->assertTrue($container->hasDefinition('snc_redis.client.default_profile'));
         $this->assertTrue($container->hasDefinition('snc_redis.client.default_options'));
         $this->assertTrue($container->hasDefinition('snc_redis.default'));
@@ -104,27 +104,27 @@ class SncRedisExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($container->hasDefinition('snc_redis.logger'));
         $this->assertTrue($container->hasDefinition('snc_redis.data_collector'));
 
-        $this->assertTrue($container->hasDefinition('snc_redis.connection.default_parameters'));
+        $this->assertTrue($container->hasDefinition('snc_redis.connection.default_default_parameters'));
         $this->assertTrue($container->hasDefinition('snc_redis.client.default_profile'));
         $this->assertTrue($container->hasDefinition('snc_redis.client.default_options'));
         $this->assertTrue($container->hasDefinition('snc_redis.default'));
         $this->assertTrue($container->hasAlias('snc_redis.default_client'));
 
-        $this->assertTrue($container->hasDefinition('snc_redis.connection.cache_parameters'));
+        $this->assertTrue($container->hasDefinition('snc_redis.connection.cache_cache_parameters'));
         $this->assertTrue($container->hasDefinition('snc_redis.client.cache_profile'));
         $this->assertTrue($container->hasDefinition('snc_redis.client.cache_options'));
         $this->assertTrue($container->hasDefinition('snc_redis.cache'));
         $this->assertTrue($container->hasAlias('snc_redis.cache_client'));
 
-        $this->assertTrue($container->hasDefinition('snc_redis.connection.monolog_parameters'));
+        $this->assertTrue($container->hasDefinition('snc_redis.connection.monolog_monolog_parameters'));
         $this->assertTrue($container->hasDefinition('snc_redis.client.monolog_profile'));
         $this->assertTrue($container->hasDefinition('snc_redis.client.monolog_options'));
         $this->assertTrue($container->hasDefinition('snc_redis.monolog'));
         $this->assertTrue($container->hasAlias('snc_redis.monolog_client'));
 
-        $this->assertTrue($container->hasDefinition('snc_redis.connection.cluster1_parameters'));
-        $this->assertTrue($container->hasDefinition('snc_redis.connection.cluster2_parameters'));
-        $this->assertTrue($container->hasDefinition('snc_redis.connection.cluster3_parameters'));
+        $this->assertTrue($container->hasDefinition('snc_redis.connection.cluster_cluster1_parameters'));
+        $this->assertTrue($container->hasDefinition('snc_redis.connection.cluster_cluster2_parameters'));
+        $this->assertTrue($container->hasDefinition('snc_redis.connection.cluster_cluster3_parameters'));
         $this->assertTrue($container->hasDefinition('snc_redis.client.cluster_profile'));
         $this->assertTrue($container->hasDefinition('snc_redis.client.cluster_options'));
         $this->assertTrue($container->hasDefinition('snc_redis.cluster'));


### PR DESCRIPTION
This PR fixes a bug where multiple DSNs/connections with the same alias will have their connection parameters overwritten. This is due to the alias being used as a unique key (e.g ```snc_redis.connection.master_parameters```) which is used when building the container definitions for the various client services. This is especially problematic when using master/slave, since Predis relies on "master" being the connection alias.

The fix is to also use the client name to build a unique key for the connection parameters. People might be relying on this bug (either through using the parameters in the container directly, or not realising the connection parameters are being shared), so could be a BC break. Keen to get feedback whether this solution is reasonable.

This fixes issue https://github.com/snc/SncRedisBundle/issues/159

Example problematic configuration below, which exhibits the "cache" client using the wrong prefix option.

````
snc_redis:
    clients:
        session:
          type: predis
          alias: session
          dsn:
              - redis://127.0.0.1:6379/0?alias=master
              - redis://127.0.0.1:6380/0
          logging: %kernel.debug%
          options:
              replication: true
              prefix: 'session'
        cache:
          type: predis
          alias: cache
          dsn:
              - redis://127.0.0.1:6379/1?alias=master
              - redis://127.0.0.1:6380/1
          options:
              replication: true
              prefix: 'cache'
```

Duplicate PR of #165, re-opened due to being against the wrong branch in the fork.