### PR TITLE
Pass the path parameter to deduplicate persistent connections

### DIFF
--- a/DependencyInjection/SncRedisExtension.php
+++ b/DependencyInjection/SncRedisExtension.php
@@ -144,6 +144,9 @@ class SncRedisExtension extends Extension
                 $connection['scheme'] = 'tcp';
                 $connection['host'] = $dsn->getHost();
                 $connection['port'] = $dsn->getPort();
+                if (null !== $dsn->getDatabase()) {
+                    $connection['path'] = $dsn->getDatabase();
+                }
             }
             if (null !== $dsn->getDatabase()) {
                 $connection['database'] = $dsn->getDatabase();


### PR DESCRIPTION
When using persistent connections, Predis should be provided with a 'path' that matches the database number. This will cause the underlying connection resource to be correctly deduplicated, preventing commands from being run on the wrong database.

Fixes #185 
