### PR TITLE
Update PHPUnit to stable version, load using Composer

### DIFF
--- a/Tests/CommandTestCase.php
+++ b/Tests/CommandTestCase.php
@@ -12,6 +12,7 @@
 namespace Snc\RedisBundle\Tests;
 
 use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Snc\RedisBundle\Client\Phpredis\Client as PhpredisClient;
 
 /**
  * Base Class for command tests
@@ -32,7 +33,7 @@ abstract class CommandTestCase extends \PHPUnit_Framework_TestCase
     protected $predisClient;
 
     /**
-     * @var \Snc\RedisBundle\Client\Phpredis\Client
+     * @var PhpredisClient
      */
     protected $phpredisClient;
 
@@ -50,6 +51,12 @@ abstract class CommandTestCase extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
         $this->application = new Application($kernel);
+
+        $this->predisClient = $this->getMock('\\Predis\\Client');
+
+        $this->phpredisClient = $this->getMockBuilder('PhpredisClient')
+            ->disableOriginalConstructor()
+            ->getMock();
 
         $this->container = $this->getMock('\\Symfony\\Component\\DependencyInjection\\ContainerInterface');
 

--- a/Tests/Doctrine/Cache/RedisCacheTest.php
+++ b/Tests/Doctrine/Cache/RedisCacheTest.php
@@ -20,6 +20,7 @@ use Snc\RedisBundle\Doctrine\Cache\RedisCache;
 class RedisCacheTest extends CacheTest
 {
     protected $_redis;
+    protected $_namespace;
 
     /**
      * {@inheritdoc}
@@ -47,12 +48,16 @@ class RedisCacheTest extends CacheTest
                 $this->markTestSkipped(sprintf('The %s requires a redis instance listening on %s.', __CLASS__, $config));
             }
         }
+
+        // Use a unique namespace
+        $this->_namespace = uniqid(__METHOD__, true);
     }
 
     protected function _getCacheDriver()
     {
         $driver = new RedisCache();
         $driver->setRedis($this->_redis);
+        $driver->setNamespace($this->_namespace);
 
         return $driver;
     }

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
         "doctrine/cache": "1.*",
         "predis/predis": "~1.0",
         "symfony/console": "~2.1|~3.0",
-        "symfony/phpunit-bridge": "~2.7|~3.0"
+        "symfony/phpunit-bridge": "~2.7|~3.0",
+        "phpunit/phpunit": "4.7.*"
     },
     "suggest": {
         "monolog/monolog": "If you want to use the monolog redis handler.",


### PR DESCRIPTION
Instead of relying on the include path, PHPUnit is better listed in `require-dev`. This allows the version of PHPUnit being used to be specified for developers working on the bundle.

Two small fixes for the test suite are included:
 * Prompt autoloading of the Phpredis client before it is mocked
 * Prevent `RedisCacheTest` failures when re-executing tests on the same Redis instance