### PR TITLE
Update readme.md

### DIFF
--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -15,7 +15,7 @@ $ composer require snc/redis-bundle 1.1.x-dev
 If you want to use the `predis` client library, you have to add the `predis/predis` package, too.
 
 ``` bash
-$ composer require predis/predis 0.8.x-dev
+$ composer require predis/predis 1.0
 ```
 
 Add the RedisBundle to your application's kernel:


### PR DESCRIPTION
To fixed PHP Fatal error:  Class 'Predis\Profile\Factory' not found in /vendor/snc/redis-bundle/Snc/RedisBundle/DependencyInjection/SncRedisExtension.php on line 158 we have to update predis's version.
$ composer require predis/predis 0.8.x-dev to $ composer require predis/predis 1.0