### PR TITLE
Prevent exception in destructor.

### DIFF
--- a/Client/Phpredis/BaseClient.php
+++ b/Client/Phpredis/BaseClient.php
@@ -31,6 +31,8 @@ class BaseClient implements ClientInterface
     public function setRedis(Redis $redis)
     {
         $this->redis = $redis;
+
+        return $this;
     }
 
     /**
@@ -51,14 +53,27 @@ class BaseClient implements ClientInterface
 
         return call_user_func_array(array($this->redis, $name), $arguments);
     }
+    
+    /**
+     * Close connection to the redis server
+     */
+    public function close()
+    {
+        if (null !== $this->redis) {
+            $this->redis->close();
+            $this->redis = null;
+        }
+        
+        return $this;
+    }
 
     /**
      * Destructor
      */
     public function __destruct()
     {
-        if (null !== $this->redis) {
-            $this->redis->close();
-        }
+        try {
+            $this->close();
+        } catch (\RedisException $ex) {}
     }
 }


### PR DESCRIPTION
Attempting to throw an exception from a destructor (called in the time of script termination) causes a fatal error.
Note from: http://php.net/manual/en/language.oop5.decon.php#language.oop5.decon.destructor

Explicit close call that resets redis instance was provided.

Since PHPRedis can throw an exception on close, following situation happens time to time:
PHP Fatal error:  Uncaught exception 'RedisException' with message 'Redis server went away'