### PR TITLE
rename symfony2 to symfony

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 ## About ##
 
-This bundle integrates [Predis](https://github.com/nrk/predis) and [phpredis](https://github.com/nicolasff/phpredis) into your Symfony2 application.
+This bundle integrates [Predis](https://github.com/nrk/predis) and [phpredis](https://github.com/nicolasff/phpredis) into your Symfony application.
 
 ## Branches ##
 
-* Use version `1.0.*` or the `1.0` branch if you are using Symfony2 `2.0.*`. [![build status](https://secure.travis-ci.org/snc/SncRedisBundle.png?branch=1.0)](https://secure.travis-ci.org/snc/SncRedisBundle)
-* Use version `1.1.*` or the `1.1` branch if you are using Symfony2 `>=2.1,<3.0`. [![build status](https://secure.travis-ci.org/snc/SncRedisBundle.png?branch=1.1)](https://secure.travis-ci.org/snc/SncRedisBundle)
+* Use version `1.0.*` or the `1.0` branch if you are using Symfony `2.0.*`. [![build status](https://secure.travis-ci.org/snc/SncRedisBundle.png?branch=1.0)](https://secure.travis-ci.org/snc/SncRedisBundle)
+* Use version `1.1.*` or the `1.1` branch if you are using Symfony `>=2.1,<3.0`. [![build status](https://secure.travis-ci.org/snc/SncRedisBundle.png?branch=1.1)](https://secure.travis-ci.org/snc/SncRedisBundle)
 * The `master` branch targets a new major version of this bundle and contains breaking changes. Use it at your own risk! [![build status](https://secure.travis-ci.org/snc/SncRedisBundle.png?branch=master)](https://secure.travis-ci.org/snc/SncRedisBundle)
 
 This bundle is also available via [composer](https://github.com/composer/composer), find it on [packagist](http://packagist.org/packages/snc/redis-bundle).

--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -2,7 +2,7 @@
 
 ## About ##
 
-This bundle integrates [Predis](https://github.com/nrk/predis) and [phpredis](https://github.com/nicolasff/phpredis) into your Symfony2 application.
+This bundle integrates [Predis](https://github.com/nrk/predis) and [phpredis](https://github.com/nicolasff/phpredis) into your Symfony application.
 
 ## Installation ##
 

--- a/UPDATE.md
+++ b/UPDATE.md
@@ -88,7 +88,7 @@ Previously the bundle registered the caches for the `default` managers.
 ### 2011-07-01 ###
 
 The `RedisBundle` is now vendor prefixed.
-Please follow the following steps to update your Symfony2 project.
+Please follow the following steps to update your Symfony project.
 
 #### Update your kernel class ####
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "snc/redis-bundle",
     "type": "symfony-bundle",
-    "description": "A Redis bundle for Symfony2",
+    "description": "A Redis bundle for Symfony",
     "keywords": ["redis", "nosql", "symfony"],
     "homepage": "https://github.com/snc/SncRedisBundle",
     "license": "MIT",


### PR DESCRIPTION
when tagging the new release with sf3, the symfony2 labels are no longer valid since symfony3 is also supported.
In order to avoid confusion, Symfony2 has been renamed to Symfony

Note: similar stuff happened in other projects like symfony itself: https://github.com/symfony/symfony/commit/0a76b7e9fc2fcc0495312047f83843e041e28cfc

#223 