### PR TITLE
Add branch alias for master branch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,5 +34,10 @@
     },
     "config": {
         "bin-dir": "bin/"
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "2.x-dev"
+        }
     }
 }


### PR DESCRIPTION
That way people can require the upcoming 2.0 as `^2.0@dev` instead of `dev-master` which is a lot more future proof.