### PR TITLE
Fix Session Handler with Predis

### DIFF
--- a/DependencyInjection/Configuration/Configuration.php
+++ b/DependencyInjection/Configuration/Configuration.php
@@ -127,7 +127,7 @@ class Configuration implements ConfigurationInterface
                                     ->scalarNode('read_write_timeout')->defaultNull()->end()
                                     ->booleanNode('iterable_multibulk')->defaultFalse()->end()
                                     ->booleanNode('throw_errors')->defaultTrue()->end()
-                                    ->scalarNode('profile')->defaultValue('2.4')
+                                    ->scalarNode('profile')->defaultValue('default')
                                         ->beforeNormalization()
                                             ->ifTrue(function($v) { return false === is_string($v); })
                                             ->then(function($v) { return sprintf('%.1F', $v); })

--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -6,7 +6,7 @@ This bundle integrates [Predis](https://github.com/nrk/predis) and [phpredis](ht
 
 ## Prerequisite ##
 
-Session handler requires `Redis >= 2.6` for LUA scripts.
+Session handler requires `Redis >= 2.6.12` for LUA scripts and SET with options.
 
 ## Installation ##
 

--- a/Tests/Session/Storage/Handler/RedisSessionHandlerTest.php
+++ b/Tests/Session/Storage/Handler/RedisSessionHandlerTest.php
@@ -98,7 +98,13 @@ class RedisSessionHandlerTest extends \PHPUnit_Framework_TestCase
         $this->redis
             ->expects($this->exactly(2))
             ->method('set')
-            ->with($this->equalTo('session_symfony_locktest.lock'), $this->isType('string'), $this->equalTo(array('NX', 'PX' => $lockMaxWait * 1000 + 1)))
+            ->with(
+                $this->equalTo('session_symfony_locktest.lock'),
+                $this->isType('string'),
+                $this->equalTo('PX'),
+                $this->equalTo($lockMaxWait * 1000 + 1),
+                $this->equalTo('NX')
+            )
             ->will($this->onConsecutiveCalls(0,1))
         ;
         


### PR DESCRIPTION
Fix Predis SET function with options (#235).
Set Previs default profile with `default` value.
Fix Prerequisite section in the documentation.