### PR TITLE
Add tags for the snc_redis clients

### DIFF
--- a/DependencyInjection/SncRedisExtension.php
+++ b/DependencyInjection/SncRedisExtension.php
@@ -173,6 +173,7 @@ class SncRedisExtension extends Extension
         $optionDef->addArgument($client['options']);
         $container->setDefinition($optionId, $optionDef);
         $clientDef = new Definition($container->getParameter('snc_redis.client.class'));
+        $clientDef->addTag('snc_redis.client');
         if (1 === $connectionCount) {
             $clientDef->addArgument(new Reference(sprintf('snc_redis.connection.%s_parameters', $connectionAliases[0])));
         } else {
@@ -230,6 +231,7 @@ class SncRedisExtension extends Extension
             $phpredisDef->addArgument(new Reference('snc_redis.logger'));
         }
 
+        $phpredisDef->addTag('snc_redis.client');
         $phpredisDef->setPublic(false);
         $connectMethod = $client['options']['connection_persistent'] ? 'pconnect' : 'connect';
         $connectParameters = array();

--- a/DependencyInjection/SncRedisExtension.php
+++ b/DependencyInjection/SncRedisExtension.php
@@ -173,7 +173,7 @@ class SncRedisExtension extends Extension
         $optionDef->addArgument($client['options']);
         $container->setDefinition($optionId, $optionDef);
         $clientDef = new Definition($container->getParameter('snc_redis.client.class'));
-        $clientDef->addTag('snc_redis.client');
+        $clientDef->addTag('snc_redis.client', array('alias' => $client['alias']));
         if (1 === $connectionCount) {
             $clientDef->addArgument(new Reference(sprintf('snc_redis.connection.%s_parameters', $connectionAliases[0])));
         } else {
@@ -231,7 +231,7 @@ class SncRedisExtension extends Extension
             $phpredisDef->addArgument(new Reference('snc_redis.logger'));
         }
 
-        $phpredisDef->addTag('snc_redis.client');
+        $phpredisDef->addTag('snc_redis.client', array('alias' => $client['alias']));
         $phpredisDef->setPublic(false);
         $connectMethod = $client['options']['connection_persistent'] ? 'pconnect' : 'connect';
         $connectParameters = array();

--- a/Tests/DependencyInjection/SncRedisExtensionTest.php
+++ b/Tests/DependencyInjection/SncRedisExtensionTest.php
@@ -108,7 +108,7 @@ class SncRedisExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($container->hasDefinition('snc_redis.default'));
         $this->assertTrue($container->hasAlias('snc_redis.default_client'));
         $this->assertInternalType('array', $container->findTaggedServiceIds('snc_redis.client'));
-        $this->assertEquals(array('snc_redis.default' => array(0=>array())), $container->findTaggedServiceIds('snc_redis.client'));
+        $this->assertEquals(array('snc_redis.default' => array(array('alias' => 'default'))), $container->findTaggedServiceIds('snc_redis.client'));
     }
 
     /**
@@ -178,6 +178,8 @@ class SncRedisExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertArrayHasKey('snc_redis.cache', $tags);
         $this->assertArrayHasKey('snc_redis.monolog', $tags);
         $this->assertArrayHasKey('snc_redis.cluster', $tags);
+        $this->assertArraySubset(array('snc_redis.cache' => array(array('alias' => 'cache'))), $tags);
+        $this->assertArraySubset(array('snc_redis.cluster' => array(array('alias' => 'cluster'))), $tags);
     }
 
     /**
@@ -284,7 +286,7 @@ class SncRedisExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($masterParameters['replication']);
 
         $this->assertInternalType('array', $container->findTaggedServiceIds('snc_redis.client'));
-        $this->assertEquals(array('snc_redis.default' => array(0=>array())), $container->findTaggedServiceIds('snc_redis.client'));
+        $this->assertEquals(array('snc_redis.default' => array(array('alias' => 'default'))), $container->findTaggedServiceIds('snc_redis.client'));
     }
 
     private function parseYaml($yaml)


### PR DESCRIPTION
Allows the clients to be found without previously knowing their names.