### PR TITLE
Rewritten DSN parsing to use parse_url and parse_str to comply with rfc3986 (fixes #218)

### DIFF
--- a/DependencyInjection/Configuration/RedisDsn.php
+++ b/DependencyInjection/Configuration/RedisDsn.php
@@ -156,6 +156,11 @@ class RedisDsn
         if (false !== $pos = strrpos($dsn, '@')) {
             // parse password
             $this->password = str_replace('\@', '@', substr($dsn, 0, $pos));
+
+            if (strstr($this->password, ':')) {
+                list(, $this->password) = explode(':', $this->password);
+            }
+
             $dsn = substr($dsn, $pos + 1);
         }
         $dsn = preg_replace_callback('/\?(weight|alias)=[^&]+.*$/', array($this, 'parseParameters'), $dsn); // parse parameters


### PR DESCRIPTION
See issue #218 for more info. This change makes sure the URL is parsed properly to just extract the password.