### PR TITLE
Properly extract password from auth credentials (fixes #218)

### DIFF
--- a/DependencyInjection/Configuration/RedisDsn.php
+++ b/DependencyInjection/Configuration/RedisDsn.php
@@ -156,6 +156,11 @@ class RedisDsn
         if (false !== $pos = strrpos($dsn, '@')) {
             // parse password
             $this->password = str_replace('\@', '@', substr($dsn, 0, $pos));
+
+            if (strstr($this->password, ':')) {
+                list(, $this->password) = explode(':', $this->password);
+            }
+
             $dsn = substr($dsn, $pos + 1);
         }
         $dsn = preg_replace_callback('/\?(weight|alias)=[^&]+.*$/', array($this, 'parseParameters'), $dsn); // parse parameters


### PR DESCRIPTION
Allows urls like postgres://h:password@host.com:1234 to work. I also attempted to rewrite using parse_url & parse_str as suggested in #218, however due to the implementation of socket location parsing, which parse_url doesn't support, this would lead to too much boilerplate code, making it simpler to just add an easy fix.