### PR TITLE
Don't show wrapper HTML when no icon is visible in profile bar.

### DIFF
--- a/Resources/views/Collector/redis.html.twig
+++ b/Resources/views/Collector/redis.html.twig
@@ -3,45 +3,66 @@
 {% block toolbar %}
     {% set profiler_markup_version = profiler_markup_version|default(1) %}
 
-    {% set icon %}
-        {% if profiler_markup_version == 1 %}
+    {% if profiler_markup_version == 1 %}
+        {% set icon %}
             <img width="20" height="28" alt="Redis" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAcCAYAAABh2p9gAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAv5JREFUeNrsVd9L01EUP9/tbm5ubtI2VqAOYpJP0WCYNOilQAiySbICHyp67CXqrf8jqKeejAVJ9GAUmUEMfYjSl5IYexqM1G3Mn1O3uT6fy+4QMV/yoQe/cLi7557zOZ/zOder1Ww25Tg/mxzzdwL4HwKqZDJ51Pkpy7JGtre3r9dqtbMul2vB4XBM4qp9gr962JVTBx0IcsIS+HkL64jP5zuTSqWkXq9LPp+/MDs7e1cp9QuAk4h5iZgfhwIioB8sxvb29m673e7z2Eu1WpVwOCwDAwMSi8VkZmZGcrmcFIvFc7u7u09sNttjgH8B6CvYW8AUrdHR0SvYPETA1Wg06hofH5dQKMQCUqlUZGJiQhYXFyWRSMj8/Lxsbm7KxsZG27q7u3W80+ksAeepWltbe9TZ2XmNLDs6OiQQCEhvb6/Y7Xa2r1uFhjI3Nycej0dQWPtZEJoKutGxOzs7ARRIWWjlPdCHASoQXAd4vV4N1NPTI0NDQxKJRHSR6elpSafTgjbboCxApltbW9JoNL4qv9//HVoNsz1WIksGoIgUCgXJZrPS19cny8vLMjU1pWOQqPUlCJi12fIWKLQRwSR1WwTiykACMolAmUxGF+LeALEDMu3q6tJSsDvkDqqlpaUg26ST4mLSWngmQV/BJDU4pq/P2Cr36EzLQ3aMLZfLZGtXSMgRgMZAApMxE8iGftMWWZIR2yPD9fV1fW7YImdBBYNBDydsWLESmXFINJxrzfi1psl7qKUhaxYhAbJFXL8qlUqnmcjKPDCsWJ3WElsDmiFQBiMTAenjUFHEr4D6e3V1VQ+EiYYV2yCwGQS1o/C8yIwhKP0rKyvmbjbhe8c/vQf48Rn7+wC4BBY2JjKJjM0NMBqyTRYnGIvCX4K9gT0D1jcrHo/vf8oGcXAP4DeQGKZmbI1mWjZsEfcTrhd8IGCF9puwD9A8ElxCSLqJ9Q7Wi3S3jhs4/4D1OewjrHrwtfoboLTeOjvsMmwMVoO9hmWOekCtk//L//z9EWAADA/Sh+MqnZ4AAAAASUVORK5CYII="/>
 
             <span class="sf-toolbar-status">{{ collector.commandcount }}</span>
-        {% else %}
-            {% if collector.commandcount > 0 %}
-                {{ include('@SncRedis/Collector/icon.svg.twig') }}
+        {% endset %}
 
-                <span class="sf-toolbar-value">{{ collector.commandCount }}</span>
-                <span class="sf-toolbar-info-piece-additional-detail">
-                    <span class="sf-toolbar-label">in</span>
-                    <span class="sf-toolbar-value">{{ '%0.2f'|format(collector.time) }}</span>
-                    <span class="sf-toolbar-label">ms</span>
-                </span>
-            {% endif %}
-        {% endif %}
-    {% endset %}
-
-    {% set text %}
-        <div class="sf-toolbar-info-piece">
-            <b>Queries</b>
-            <span class="sf-toolbar-status">{{ collector.commandcount }}</span>
-        </div>
-
-        <div class="sf-toolbar-info-piece">
-            <b>Query time</b>
-            <span>{{ '%0.2f'|format(collector.time) }} ms</span>
-        </div>
-
-        {% if collector.erroredCommandsCount > 0 %}
+        {% set text %}
             <div class="sf-toolbar-info-piece">
-                <b>Failed Queries</b>
-                <span class="sf-toolbar-status sf-toolbar-status-red">{{ collector.erroredCommandsCount }}</span>
+                <b>Queries</b>
+                <span class="sf-toolbar-status">{{ collector.commandcount }}</span>
             </div>
-        {% endif %}
-    {% endset %}
 
-    {% include 'WebProfilerBundle:Profiler:toolbar_item.html.twig' with { 'link': profiler_url, status: collector.erroredCommandsCount > 0 ? 'red' : '' } %}
+            <div class="sf-toolbar-info-piece">
+                <b>Query time</b>
+                <span>{{ '%0.2f'|format(collector.time) }} ms</span>
+            </div>
+
+            {% if collector.erroredCommandsCount > 0 %}
+                <div class="sf-toolbar-info-piece">
+                    <b>Failed Queries</b>
+                    <span class="sf-toolbar-status sf-toolbar-status-red">{{ collector.erroredCommandsCount }}</span>
+                </div>
+            {% endif %}
+        {% endset %}
+
+        {% include 'WebProfilerBundle:Profiler:toolbar_item.html.twig' with { 'link': profiler_url, status: collector.erroredCommandsCount > 0 ? 'red' : '' } %}
+    {% elseif collector.commandcount > 0 %}
+        {% set icon %}
+            {{ include('@SncRedis/Collector/icon.svg.twig') }}
+
+            <span class="sf-toolbar-value">{{ collector.commandCount }}</span>
+            <span class="sf-toolbar-info-piece-additional-detail">
+                <span class="sf-toolbar-label">in</span>
+                <span class="sf-toolbar-value">{{ '%0.2f'|format(collector.time) }}</span>
+                <span class="sf-toolbar-label">ms</span>
+            </span>
+        {% endset %}
+
+        {% set text %}
+            <div class="sf-toolbar-info-piece">
+                <b>Queries</b>
+                <span class="sf-toolbar-status">{{ collector.commandcount }}</span>
+            </div>
+
+            <div class="sf-toolbar-info-piece">
+                <b>Query time</b>
+                <span>{{ '%0.2f'|format(collector.time) }} ms</span>
+            </div>
+
+            {% if collector.erroredCommandsCount > 0 %}
+                <div class="sf-toolbar-info-piece">
+                    <b>Failed Queries</b>
+                    <span class="sf-toolbar-status sf-toolbar-status-red">{{ collector.erroredCommandsCount }}</span>
+                </div>
+            {% endif %}
+        {% endset %}
+
+        {% include 'WebProfilerBundle:Profiler:toolbar_item.html.twig' with { 'link': profiler_url, status: collector.erroredCommandsCount > 0 ? 'red' : '' } %}
+    {% endif %}
 {% endblock %}
 
 {% block menu %}


### PR DESCRIPTION
This fixes a glitch in the profile bar icon for the new style profile bar. Item was always visible, even when no icon and text was shown.

#251