### PR TITLE
Fixes phpredis persistent connections when clients connect to different DBs

### DIFF
--- a/DependencyInjection/SncRedisExtension.php
+++ b/DependencyInjection/SncRedisExtension.php
@@ -245,6 +245,9 @@ class SncRedisExtension extends Extension
         if ($client['options']['connection_timeout']) {
             $connectParameters[] = $client['options']['connection_timeout'];
         }
+        if ($client['options']['connection_persistent']) {
+            $connectParameters[] = md5(implode('', $connectParameters) . $dsn->getDatabase());
+        }
 
         $phpredisDef->addMethodCall($connectMethod, $connectParameters);
         if ($client['options']['prefix']) {


### PR DESCRIPTION
This fixes the corner case where clients connecting to different redis databases are used with persistent connection enabled by giving a unique ID to the persistent connections.

eg:

config:

```
snc_redis:
    clients:
        db1:
            type: phpredis
            alias: db1
            dsn: redis://localhost/1
            logging: %kernel.debug%
            options:
                connection_persistent: true

        db2:
            type: phpredis
            alias: db2
            dsn: redis://localhost/2
            logging: %kernel.debug%
            options:
                connection_persistent: true
```

code:

```
$db1 = $this->getContainer()->get('snc_redis.db1');
$db2 = $this->getContainer()->get('snc_redis.db2');
$db1->set('cachekey1', 'cachevalue');
$db2->set('importantkey2', 'importantvalue');
$db1->flushDb(); // db 2 will be flushed instead of db 1 
```

From phpredis documentation:

```
$redis->pconnect('127.0.0.1', 6379, 2.5, 'x'); // x is sent as persistent_id and would be another connection the the three before.
```
