### PR TITLE
Update RateLimit.php to correct post URL

### DIFF
--- a/Extra/RateLimit.php
+++ b/Extra/RateLimit.php
@@ -19,7 +19,7 @@ use Predis\Transaction\MultiExec;
  * Redis library `Redback` for Node.JS.
  *
  * @see https://github.com/chriso/redback/blob/master/lib/advanced_structures/RateLimit.js
- * @see http://chris6f.com/rate-limiting-with-redis
+ * @see https://gist.github.com/chriso/54dd46b03155fcf555adccea822193da
  *
  * Usage:
  *


### PR DESCRIPTION
The link in the file for how to use the class is no longer valid.
The node repo from which this class was ported has been updated to reference the new URL
https://github.com/chriso/redback
 
This file should be updated to the changed URL.