### PR TITLE
Update the maintenance status badge

### DIFF
--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -1,4 +1,4 @@
-# RedisBundle ![project status](http://stillmaintained.com/snc/SncRedisBundle.png) [![build status](https://secure.travis-ci.org/snc/SncRedisBundle.png?branch=master)](https://secure.travis-ci.org/snc/SncRedisBundle) #
+# RedisBundle ![project status](https://img.shields.io/maintenance/yes/2016.svg?maxAge=2592000) [![build status](https://secure.travis-ci.org/snc/SncRedisBundle.png?branch=master)](https://secure.travis-ci.org/snc/SncRedisBundle) #
 
 ## About ##
 


### PR DESCRIPTION
Since `stillmaintained.com` is for sale, here's a simple replacement for the maintenance badge.