### PR TITLE
clarify docs around urlencoding chars in password

### DIFF
--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -41,6 +41,8 @@ public function registerBundles()
 
 Configure the `redis` client(s) in your `config.yml`:
 
+_Please note that passwords with special characters in the DSN string such as `@ % : +` must be urlencoded._
+
 ``` yaml
 snc_redis:
     clients:


### PR DESCRIPTION
missed the part about encoding specific characters in the DSN password string
adding it to the docs would be helpful
here it is!