### PR TITLE
set redis unavailable if it does not ping on bundle boot

### DIFF
--- a/Client/Predis/Client.php
+++ b/Client/Predis/Client.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Snc\RedisBundle\Client\Predis;
+
+use Predis\Client as PredisClient;
+
+/**
+ * Class Client
+ * @package Snc\RedisBundle\Client
+ */
+class Client extends PredisClient
+{
+
+    /**
+     * Determines whether redis server is available or not
+     * @var bool
+     */
+    protected static $available = true;
+
+    /**
+     * Sets redis as unavailable
+     */
+    public function setUnavailable()
+    {
+        static::$available = false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __call($commandID, $arguments)
+    {
+        return true === static::$available ?
+            parent::__call($commandID, $arguments) :
+            (preg_match('/set/', $commandID) ? 'OK' : null);
+    }
+
+}

--- a/DependencyInjection/Configuration/Configuration.php
+++ b/DependencyInjection/Configuration/Configuration.php
@@ -44,7 +44,7 @@ class Configuration implements ConfigurationInterface
                 ->arrayNode('class')
                     ->addDefaultsIfNotSet()
                     ->children()
-                        ->scalarNode('client')->defaultValue('Predis\Client')->end()
+                        ->scalarNode('client')->defaultValue('Snc\RedisBundle\Client\Predis\Client')->end()
                         ->scalarNode('client_options')->defaultValue('Predis\Configuration\Options')->end()
                         ->scalarNode('connection_parameters')->defaultValue('Predis\Connection\Parameters')->end()
                         ->scalarNode('connection_factory')->defaultValue('Snc\RedisBundle\Client\Predis\Connection\ConnectionFactory')->end()

--- a/Tests/Client/Predis/ClientTest.php
+++ b/Tests/Client/Predis/ClientTest.php
@@ -33,7 +33,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         if (!method_exists($this, 'expectException'))
             $this->markTestSkipped('This test needs PHPUnit >= 5.2.0');
 
-        $this->expectException(PredisException::class);
+        $this->expectException('Predis\PredisException');
         $this->client->ping();
     }
 

--- a/Tests/Client/Predis/ClientTest.php
+++ b/Tests/Client/Predis/ClientTest.php
@@ -43,7 +43,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($this->client->get('foo:bar'));
         $this->assertNull($this->client->hget('foo:bar', 'foo'));
         $this->assertNull($this->client->hgetall('foo:bar'));
-        $this->assertNull($this->client->hmget('foo:bar', []));
+        $this->assertNull($this->client->hmget('foo:bar', array()));
     }
 
     public function testSetCommandString()
@@ -51,7 +51,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('OK', $this->client->set('foo', 'bar'));
         $this->assertEquals('OK', $this->client->setex('foo', 10,'bar'));
         $this->assertEquals('OK', $this->client->psetex('foo', 10,'bar'));
-        $this->assertEquals('OK', $this->client->hmset('foo', ['a' => 5]));
-        $this->assertEquals('OK', $this->client->mset(['foo', 'bar']));
+        $this->assertEquals('OK', $this->client->hmset('foo', array('a' => 5)));
+        $this->assertEquals('OK', $this->client->mset(array('foo', 'bar')));
     }
 }

--- a/Tests/Client/Predis/ClientTest.php
+++ b/Tests/Client/Predis/ClientTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Snc\RedisBundle\Tests\Client\Predis;
+
+use Predis\PredisException;
+use Snc\RedisBundle\Client\Predis\Client;
+
+/**
+ * ClientTest
+ */
+class ClientTest extends \PHPUnit_Framework_TestCase
+{
+
+    /**
+     * @var Client
+     */
+    protected $client;
+
+    public function setUp()
+    {
+        $this->client = new Client([
+            'scheme' => 'tcp',
+            'host'   => 'foo.redis.local',
+            'port'   => 6379,
+        ]);
+    }
+
+    /**
+     * @covers \Snc\RedisBundle\Client\Phpredis\Client::getCommandString
+     */
+    public function testPingException()
+    {
+        $this->expectException(PredisException::class);
+        $this->client->ping();
+    }
+
+    public function testGetCommandString()
+    {
+        $this->client->setUnavailable();
+        $this->assertTrue(null === $this->client->get('foo:bar'));
+        $this->assertTrue(null === $this->client->hget('foo:bar', 'foo'));
+        $this->assertTrue(null === $this->client->hgetall('foo:bar'));
+        $this->assertTrue(null === $this->client->hmget('foo:bar', []));
+    }
+
+    public function testSetCommandString()
+    {
+        $this->assertTrue('OK'=== $this->client->set('foo', 'bar'));
+        $this->assertTrue('OK'=== $this->client->setex('foo', 10,'bar'));
+        $this->assertTrue('OK'=== $this->client->psetex('foo', 10,'bar'));
+        $this->assertTrue('OK'=== $this->client->hmset('foo', ['a' => 5]));
+        $this->assertTrue('OK'=== $this->client->mset(['foo', 'bar']));
+    }
+}

--- a/Tests/Client/Predis/ClientTest.php
+++ b/Tests/Client/Predis/ClientTest.php
@@ -18,11 +18,11 @@ class ClientTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->client = new Client([
+        $this->client = new Client(array(
             'scheme' => 'tcp',
             'host'   => 'foo.redis.local',
             'port'   => 6379,
-        ]);
+        ));
     }
 
     /**
@@ -43,7 +43,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue(null === $this->client->get('foo:bar'));
         $this->assertTrue(null === $this->client->hget('foo:bar', 'foo'));
         $this->assertTrue(null === $this->client->hgetall('foo:bar'));
-        $this->assertTrue(null === $this->client->hmget('foo:bar', []));
+        $this->assertTrue(null === $this->client->hmget('foo:bar', array()));
     }
 
     public function testSetCommandString()
@@ -51,7 +51,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue('OK'=== $this->client->set('foo', 'bar'));
         $this->assertTrue('OK'=== $this->client->setex('foo', 10,'bar'));
         $this->assertTrue('OK'=== $this->client->psetex('foo', 10,'bar'));
-        $this->assertTrue('OK'=== $this->client->hmset('foo', ['a' => 5]));
-        $this->assertTrue('OK'=== $this->client->mset(['foo', 'bar']));
+        $this->assertTrue('OK'=== $this->client->hmset('foo', array('a' => 5)));
+        $this->assertTrue('OK'=== $this->client->mset(array('foo', 'bar')));
     }
 }

--- a/Tests/Client/Predis/ClientTest.php
+++ b/Tests/Client/Predis/ClientTest.php
@@ -30,6 +30,9 @@ class ClientTest extends \PHPUnit_Framework_TestCase
      */
     public function testPingException()
     {
+        if (!method_exists($this, 'expectException'))
+            $this->markTestSkipped('This test needs PHPUnit >= 5.2.0');
+
         $this->expectException(PredisException::class);
         $this->client->ping();
     }

--- a/Tests/Client/Predis/ClientTest.php
+++ b/Tests/Client/Predis/ClientTest.php
@@ -40,18 +40,18 @@ class ClientTest extends \PHPUnit_Framework_TestCase
     public function testGetCommandString()
     {
         $this->client->setUnavailable();
-        $this->assertTrue(null === $this->client->get('foo:bar'));
-        $this->assertTrue(null === $this->client->hget('foo:bar', 'foo'));
-        $this->assertTrue(null === $this->client->hgetall('foo:bar'));
-        $this->assertTrue(null === $this->client->hmget('foo:bar', array()));
+        $this->assertNull($this->client->get('foo:bar'));
+        $this->assertNull($this->client->hget('foo:bar', 'foo'));
+        $this->assertNull($this->client->hgetall('foo:bar'));
+        $this->assertNull($this->client->hmget('foo:bar', []));
     }
 
     public function testSetCommandString()
     {
-        $this->assertTrue('OK'=== $this->client->set('foo', 'bar'));
-        $this->assertTrue('OK'=== $this->client->setex('foo', 10,'bar'));
-        $this->assertTrue('OK'=== $this->client->psetex('foo', 10,'bar'));
-        $this->assertTrue('OK'=== $this->client->hmset('foo', array('a' => 5)));
-        $this->assertTrue('OK'=== $this->client->mset(array('foo', 'bar')));
+        $this->assertEquals('OK', $this->client->set('foo', 'bar'));
+        $this->assertEquals('OK', $this->client->setex('foo', 10,'bar'));
+        $this->assertEquals('OK', $this->client->psetex('foo', 10,'bar'));
+        $this->assertEquals('OK', $this->client->hmset('foo', ['a' => 5]));
+        $this->assertEquals('OK', $this->client->mset(['foo', 'bar']));
     }
 }

--- a/Tests/DependencyInjection/SncRedisExtensionTest.php
+++ b/Tests/DependencyInjection/SncRedisExtensionTest.php
@@ -35,7 +35,7 @@ class SncRedisExtensionTest extends \PHPUnit_Framework_TestCase
     public static function parameterValues()
     {
         return array(
-            array('snc_redis.client.class', 'Predis\Client'),
+            array('snc_redis.client.class', 'Snc\RedisBundle\Client\Predis\Client'),
             array('snc_redis.client_options.class', 'Predis\Configuration\Options'),
             array('snc_redis.connection_parameters.class', 'Predis\Connection\Parameters'),
             array('snc_redis.connection_factory.class', 'Snc\RedisBundle\Client\Predis\Connection\ConnectionFactory'),


### PR DESCRIPTION
If redis down applications relying on it crash.
I think an application should not crash if redis is unavailable, unless it is your primary database.

Works fine with Doctrine's PredisCache, but must pay attention for custom use of client.
If redis down it will return null for every command except for 'set' family commands that will return 'OK' string.

Even if could be not complete, and this pull request will be rejected, please consider the feature.

Best Regards

Nelson
