### PR TITLE
Use .svg image instead of .png for Travis badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ This bundle integrates [Predis](https://github.com/nrk/predis) and [phpredis](ht
 
 ## Branches ##
 
-* Use version `2.*` for Symfony 2.7+ and 3.0+. [![build status](https://secure.travis-ci.org/snc/SncRedisBundle.png?branch=master)](https://secure.travis-ci.org/snc/SncRedisBundle)
-* Use version `1.1.*` or the `1.1` branch if you are using Symfony `>=2.1,<3.0`. [![build status](https://secure.travis-ci.org/snc/SncRedisBundle.png?branch=1.1)](https://secure.travis-ci.org/snc/SncRedisBundle)
-* Use version `1.0.*` or the `1.0` branch if you are using Symfony `2.0.*`. [![build status](https://secure.travis-ci.org/snc/SncRedisBundle.png?branch=1.0)](https://secure.travis-ci.org/snc/SncRedisBundle)
+* Use version `2.*` for Symfony 2.7+ and 3.0+. [![build status](https://secure.travis-ci.org/snc/SncRedisBundle.svg?branch=master)](https://secure.travis-ci.org/snc/SncRedisBundle)
+* Use version `1.1.*` or the `1.1` branch if you are using Symfony `>=2.1,<3.0`. [![build status](https://secure.travis-ci.org/snc/SncRedisBundle.svg?branch=1.1)](https://secure.travis-ci.org/snc/SncRedisBundle)
+* Use version `1.0.*` or the `1.0` branch if you are using Symfony `2.0.*`. [![build status](https://secure.travis-ci.org/snc/SncRedisBundle.svg?branch=1.0)](https://secure.travis-ci.org/snc/SncRedisBundle)
 
 This bundle is also available via [composer](https://github.com/composer/composer), find it on [packagist](http://packagist.org/packages/snc/redis-bundle).
 


### PR DESCRIPTION
The .svg format has better quality.
