### PR TITLE
removed defaultValue for replication option to allow cluster option

### DIFF
--- a/DependencyInjection/Configuration/Configuration.php
+++ b/DependencyInjection/Configuration/Configuration.php
@@ -135,7 +135,7 @@ class Configuration implements ConfigurationInterface
                                     ->end()
                                     ->scalarNode('cluster')->defaultNull()->end()
                                     ->scalarNode('prefix')->defaultNull()->end()
-                                    ->booleanNode('replication')->defaultFalse()->end()
+                                    ->booleanNode('replication')->end()
                                 ->end()
                             ->end()
                         ->end()


### PR DESCRIPTION
Predis now has built-in support for redis-cluster:
https://github.com/nrk/predis/blob/v1.1/README.md#cluster

However this options has only effect when the replication option is omitted.
But due to the defaultFalse configuration, the option['replication'] was always present and prevented Predis to enter cluster mode:
https://github.com/nrk/predis/blob/v1.1/src/Client.php#L123

An example config is:

```
snc_redis:
    clients:
      default:
          type: predis
          alias: default
          dsn:
              - 'redis://%cache.redis_host.one%:%cache.redis_port%/%cache.redis_db%'
              - 'redis://%cache.redis_host.two%:%cache.redis_port%/%cache.redis_db%'
          options:
            profile: 3.2
            cluster: "redis"
```

With "redis-custer" or "redis" as cluster option commands like this will automatically be resolved:
MOVED 14966 cache.redis_host.two:6381

This probably needs some more work as replication now can be even more than boolean:
https://github.com/nrk/predis/blob/v1.1/README.md#replication