### PR TITLE
Use persistent id generated from DSN, if connection_persistent is set to 'true'

### DIFF
--- a/DependencyInjection/Configuration/RedisDsn.php
+++ b/DependencyInjection/Configuration/RedisDsn.php
@@ -127,13 +127,13 @@ class RedisDsn
         return $this->alias;
     }
 	
-	/**
-	 * @return string
-	 */
-	public function getPersistentId() 
-	{
-		return md5($this->dsn);
-	}
+    /**
+     * @return string
+     */
+    public function getPersistentId() 
+    {
+        return md5($this->dsn);
+    }
 
     /**
      * @return bool

--- a/DependencyInjection/Configuration/RedisDsn.php
+++ b/DependencyInjection/Configuration/RedisDsn.php
@@ -126,6 +126,14 @@ class RedisDsn
     {
         return $this->alias;
     }
+	
+	/**
+	 * @return string
+	 */
+	public function getPersistentId() 
+	{
+		return md5($this->dsn);
+	}
 
     /**
      * @return bool

--- a/DependencyInjection/SncRedisExtension.php
+++ b/DependencyInjection/SncRedisExtension.php
@@ -245,6 +245,12 @@ class SncRedisExtension extends Extension
         if ($client['options']['connection_timeout']) {
             $connectParameters[] = $client['options']['connection_timeout'];
         }
+		else {
+			$connectParameters[] = null;
+		}
+		if($client['options']['connection_persistent']) {
+			$connectParameters[] = $dsn->getPersistentId();
+		}
 
         $phpredisDef->addMethodCall($connectMethod, $connectParameters);
         if ($client['options']['prefix']) {

--- a/DependencyInjection/SncRedisExtension.php
+++ b/DependencyInjection/SncRedisExtension.php
@@ -245,12 +245,12 @@ class SncRedisExtension extends Extension
         if ($client['options']['connection_timeout']) {
             $connectParameters[] = $client['options']['connection_timeout'];
         }
-		else {
-			$connectParameters[] = null;
-		}
-		if($client['options']['connection_persistent']) {
-			$connectParameters[] = $dsn->getPersistentId();
-		}
+        else {
+            $connectParameters[] = null;
+        }
+        if($client['options']['connection_persistent']) {
+            $connectParameters[] = $dsn->getPersistentId();
+        }
 
         $phpredisDef->addMethodCall($connectMethod, $connectParameters);
         if ($client['options']['prefix']) {


### PR DESCRIPTION
If multiple connections are used and the option "connection_persistent" is set to true, the second instance currently uses the connection from the first instance. To prevent that from happening, a persistentId is required.

In this fix I just created a md5 hash from the DSN and used it as persistentId. 