### PR TITLE
To be more consistent, command-content should be considered debug out…

### DIFF
--- a/Logger/RedisLogger.php
+++ b/Logger/RedisLogger.php
@@ -62,7 +62,7 @@ class RedisLogger
                     $this->logger->err($message);
                 }
             } else {
-                $this->logger->info('Executing command "' . $command . '"');
+                $this->logger->debug('Executing command "' . $command . '"');
             }
         }
     }


### PR DESCRIPTION
…put. It can fill up logs pretty quickly when used in loops. Thus changed loglevel for command output to DEBUG

Bundles such as Doctrine also DEBUG output commands instead of using INFO.

imho INFO is the wrong log-level for command output. Also INFO is often used for informative Messages in a system, when log-level is left to INFO and a background process is having redis in a loop, it pollutes the log extremely with trillions of GET or SET commands.

So i propose to change this.