### PR TITLE
Allow Redis DSN with DB as env param

### DIFF
--- a/DependencyInjection/Configuration/RedisDsn.php
+++ b/DependencyInjection/Configuration/RedisDsn.php
@@ -126,11 +126,11 @@ class RedisDsn
     {
         return $this->alias;
     }
-	
+
     /**
      * @return string
      */
-    public function getPersistentId() 
+    public function getPersistentId()
     {
         return md5($this->dsn);
     }
@@ -174,9 +174,12 @@ class RedisDsn
             $dsn = substr($dsn, $pos + 1);
         }
         $dsn = preg_replace_callback('/\?(.*)$/', array($this, 'parseParameters'), $dsn); // parse parameters
-        if (preg_match('#^(.*)/(\d+)$#', $dsn, $matches)) {
+        if (preg_match('#^(.*)/([0-9a-z_]+)$#', $dsn, $matches)) {
             // parse database
-            $this->database = (int) $matches[2];
+            $this->database = $matches[2];
+            if (false !== filter_var($matches[2], FILTER_VALIDATE_INT)) {
+                $this->database = (int) $matches[2];
+            }
             $dsn = $matches[1];
         }
         if (preg_match('#^([^:]+)(:(\d+))?$#', $dsn, $matches)) {

--- a/Tests/DependencyInjection/Configuration/RedisDsnTest.php
+++ b/Tests/DependencyInjection/Configuration/RedisDsnTest.php
@@ -148,6 +148,34 @@ class RedisDsnTest extends \PHPUnit_Framework_TestCase
             array('redis:///redis.sock:63790', null),
             array('redis:///redis.sock:63790/10', 10),
             array('redis://pw@/redis.sock:63790/10', 10),
+            array(
+                'redis://localhost/_f8e13c0dd01c2d40bb147771c5d38582',
+                '_f8e13c0dd01c2d40bb147771c5d38582'
+            ),
+            array(
+                'redis://127.0.0.1/env_f7a25e8044d411d3517810b0afd69327',
+                'env_f7a25e8044d411d3517810b0afd69327'
+            ),
+            array(
+                'redis://pw@127.0.0.1:63790/env_redis_db',
+                'env_redis_db'
+            ),
+            array(
+                'redis:///redis.sock/env',
+                'env'
+            ),
+            array(
+                'redis:///redis.sock/env_redis_db_2ef83c26da59817a13c2e267b8772e93',
+                'env_redis_db_2ef83c26da59817a13c2e267b8772e93'
+            ),
+            array(
+                'redis:///redis.sock:63790/env_redis_db_784765a7e1f47f159583e249cd9ffd92',
+                'env_redis_db_784765a7e1f47f159583e249cd9ffd92'
+            ),
+            array(
+                'redis://pw@/redis.sock:63790/env_redis_db_2dcc3738cf08e34826e35c9044025477',
+                'env_redis_db_2dcc3738cf08e34826e35c9044025477'
+            ),
         );
     }
 


### PR DESCRIPTION
The RedisDSN parser allows only integer values for the DB part in the DSN. In Symfony 3.2, when using an env var for the Redis db parameter, the DNS value is yet not replaced with the actual value taken from env, but a string like `param_name_f8e13c0dd01c2d40bb147771c5d38582`. This prohibits the use of a env var for the DB parameter, like:
`dsn: 'redis://%redis_password%@%redis_host%/%redis_db%'`
This PR fixed this behavior by making a broader match on the DSN.