### PR TITLE
Fixed usage of non-Twig paths

### DIFF
--- a/Resources/config/redis.xml
+++ b/Resources/config/redis.xml
@@ -13,7 +13,7 @@
         </service>
 
         <service id="snc_redis.data_collector" class="%snc_redis.data_collector.class%" public="false">
-            <tag name="data_collector" template="SncRedisBundle:Collector:redis" id="redis" />
+            <tag name="data_collector" template="@SncRedis/Collector/redis.html.twig" id="redis" />
             <argument type="service" id="snc_redis.logger" />
         </service>
     </services>

--- a/Resources/views/Collector/redis.html.twig
+++ b/Resources/views/Collector/redis.html.twig
@@ -1,4 +1,4 @@
-{% extends 'WebProfilerBundle:Profiler:layout.html.twig' %}
+{% extends '@WebProfiler/Profiler/layout.html.twig' %}
 
 {% block toolbar %}
     {% set profiler_markup_version = profiler_markup_version|default(1) %}


### PR DESCRIPTION
@snc This is a fix so we can use this bundle without twig integration with symfony.

It seems like this template naming is encouraged.

References:
https://github.com/symfony/web-profiler-bundle/commit/50d6db262e70d0e1be39ed914db19d8b3f7a645e