### PR TITLE
Improve the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,16 @@ This bundle integrates [Predis](https://github.com/nrk/predis) and [phpredis](ht
 
 ## Branches ##
 
-* Use version `2.*` for Symfony 2.7+ and 3.0+. [![build status](https://secure.travis-ci.org/snc/SncRedisBundle.svg?branch=master)](https://secure.travis-ci.org/snc/SncRedisBundle)
-* Use version `1.1.*` or the `1.1` branch if you are using Symfony `>=2.1,<3.0`. [![build status](https://secure.travis-ci.org/snc/SncRedisBundle.svg?branch=1.1)](https://secure.travis-ci.org/snc/SncRedisBundle)
-* Use version `1.0.*` or the `1.0` branch if you are using Symfony `2.0.*`. [![build status](https://secure.travis-ci.org/snc/SncRedisBundle.svg?branch=1.0)](https://secure.travis-ci.org/snc/SncRedisBundle)
+* Use version `2.*` for Symfony 2.7+ and 3.0+. [![build status](https://travis-ci.org/snc/SncRedisBundle.svg?branch=master)](https://travis-ci.org/snc/SncRedisBundle)
+* Use version `1.1.*` or the `1.1` branch if you are using Symfony `>=2.1,<3.0`. [![build status](https://travis-ci.org/snc/SncRedisBundle.svg?branch=1.1)](https://travis-ci.org/snc/SncRedisBundle)
+* Use version `1.0.*` or the `1.0` branch if you are using Symfony `2.0.*`. [![build status](https://travis-ci.org/snc/SncRedisBundle.svg?branch=1.0)](https://travis-ci.org/snc/SncRedisBundle)
 
-This bundle is also available via [composer](https://github.com/composer/composer), find it on [packagist](http://packagist.org/packages/snc/redis-bundle).
+This bundle is also available via [composer](https://github.com/composer/composer), find it on [packagist](https://packagist.org/packages/snc/redis-bundle).
 
 ## Documentation ##
 
-[Read the documentation in Resources/doc/](https://github.com/snc/SncRedisBundle/blob/master/Resources/doc/index.md)
+[Read the documentation in Resources/doc/](Resources/doc/index.md)
 
 ## License ##
 
-See [Resources/meta/LICENSE](https://github.com/snc/SncRedisBundle/blob/master/Resources/meta/LICENSE).
+See [LICENSE](LICENSE).


### PR DESCRIPTION
- Fix link to the license file (forgotten in #341)
- Avoid using the old secure subdomain of Travis
- Use HTTPS for the Packagist link
- Use relative links for the access to the doc, so that Github and Packagist link to the doc for the same version than the readme being displayed.