### PR TITLE
Fix template namespacing

### DIFF
--- a/Resources/views/Collector/redis.html.twig
+++ b/Resources/views/Collector/redis.html.twig
@@ -29,7 +29,7 @@
             {% endif %}
         {% endset %}
 
-        {% include 'WebProfilerBundle:Profiler:toolbar_item.html.twig' with { 'link': profiler_url, status: collector.erroredCommandsCount > 0 ? 'red' : '' } %}
+        {% include '@WebProfiler/Profiler/toolbar_item.html.twig' with { 'link': profiler_url, status: collector.erroredCommandsCount > 0 ? 'red' : '' } %}
     {% elseif collector.commandcount > 0 %}
         {% set icon %}
             {{ include('@SncRedis/Collector/icon.svg.twig') }}
@@ -61,7 +61,7 @@
             {% endif %}
         {% endset %}
 
-        {% include 'WebProfilerBundle:Profiler:toolbar_item.html.twig' with { 'link': profiler_url, status: collector.erroredCommandsCount > 0 ? 'red' : '' } %}
+        {% include '@WebProfiler/Profiler/toolbar_item.html.twig' with { 'link': profiler_url, status: collector.erroredCommandsCount > 0 ? 'red' : '' } %}
     {% endif %}
 {% endblock %}
 


### PR DESCRIPTION
I'm using this bundle in a Symfony 3.3 project and I have an issue when using the web profiler due to the wrong template syntax use. The twig loader is not able to find the template.