### PR TITLE
Fix RedisSpool to use Swift_Mime_SimpleMessage

### DIFF
--- a/SwiftMailer/RedisSpool.php
+++ b/SwiftMailer/RedisSpool.php
@@ -67,7 +67,7 @@ class RedisSpool extends \Swift_ConfigurableSpool
     /**
      * {@inheritdoc}
      */
-    public function queueMessage(\Swift_Mime_Message $message)
+    public function queueMessage(\Swift_Mime_SimpleMessage $message)
     {
         $this->redis->rpush($this->key, serialize($message));
 


### PR DESCRIPTION
Swift_Mime_Message extends Swift_Mime_SimpleMessage [(ref)](https://github.com/swiftmailer/swiftmailer/blob/master/lib/classes/Swift/Message.php).

When I install Symfony Swiftmailer Bundle [(ref)](https://github.com/symfony/swiftmailer-bundle) and use console command (php app/console swiftmailer:email:send), there is an error:

> PHP Fatal error:  Declaration of Snc\RedisBundle\SwiftMailer\RedisSpool::queueMessage(Swift_Mime_Message $message) must be compatible with Swift_Spool::queueMessage(Swift_Mime_SimpleMessage $message) in /my/dir/vendor/snc/redis-bundle/SwiftMailer/RedisSpool.php on line 17

So, I send the code to fix.
