### PR TITLE
Support for Heroku style REDIS_URL env variables

### DIFF
--- a/DependencyInjection/Configuration/Configuration.php
+++ b/DependencyInjection/Configuration/Configuration.php
@@ -107,7 +107,13 @@ class Configuration implements ConfigurationInterface
                                         return array_map(function($dsn) {
                                             $parsed = new RedisDsn($dsn);
 
-                                            return $parsed->isValid() ? $parsed : $dsn;
+                                            if ($parsed->isValid()) {
+                                                return $parsed;
+                                            }
+
+                                            $parsedEnv = new RedisEnvDsn($dsn);
+
+                                            return $parsedEnv->isValid() ? $parsedEnv : $dsn;
                                         }, $v);
                                     })
                                 ->end()

--- a/DependencyInjection/Configuration/RedisDsn.php
+++ b/DependencyInjection/Configuration/RedisDsn.php
@@ -14,7 +14,7 @@ namespace Snc\RedisBundle\DependencyInjection\Configuration;
 /**
  * RedisDsn
  */
-class RedisDsn
+class RedisDsn implements RedisDsnInterface
 {
     /**
      * @var string

--- a/DependencyInjection/Configuration/RedisDsnInterface.php
+++ b/DependencyInjection/Configuration/RedisDsnInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Snc\RedisBundle\DependencyInjection\Configuration;
+
+interface RedisDsnInterface
+{
+    /**
+     * @return bool
+     */
+    public function isValid();
+
+    /**
+     * @return string
+     */
+    public function getAlias();
+}

--- a/DependencyInjection/Configuration/RedisEnvDsn.php
+++ b/DependencyInjection/Configuration/RedisEnvDsn.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Snc\RedisBundle\DependencyInjection\Configuration;
+
+class RedisEnvDsn implements RedisDsnInterface
+{
+    /**
+     * @var string
+     */
+    private $dsn;
+
+    /**
+     * @param string $dsn
+     */
+    public function __construct($dsn)
+    {
+        $this->dsn = $dsn;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isValid()
+    {
+        return (bool)preg_match('#^env_\w+_[0-9a-fA-F]{32}$#', $this->dsn);
+    }
+
+    /**
+     * @return null
+     */
+    public function getAlias()
+    {
+        return null;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDsn()
+    {
+        return $this->dsn;
+    }
+}

--- a/Factory/EnvParametersFactory.php
+++ b/Factory/EnvParametersFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Snc\RedisBundle\Factory;
+
+use Predis\Connection\ParametersInterface;
+
+class EnvParametersFactory
+{
+    /**
+     * @param array $options
+     * @param string $class
+     * @param string $dsn
+     *
+     * @return ParametersInterface
+     */
+    public static function create($options, $class, $dsn)
+    {
+        $callable = array($class, 'parse');
+
+        if(!is_callable($callable)) {
+            $alias = isset($options['alias']) ? $options['alias'] : 'the client';
+
+            throw new \InvalidArgumentException(sprintf('The parameters class you defined for %s does not support parsing url like DSNs.', $alias));
+        }
+
+        $dsnOptions = call_user_func($callable, $dsn);
+
+        return new $class(array_merge($options, $dsnOptions));
+    }
+}

--- a/Tests/DependencyInjection/Configuration/RedisDsnTest.php
+++ b/Tests/DependencyInjection/Configuration/RedisDsnTest.php
@@ -267,6 +267,7 @@ class RedisDsnTest extends \PHPUnit_Framework_TestCase
             array('localhost', false),
             array('localhost/1', false),
             array('pw@localhost:63790/10', false),
+            array('env_REDIS_URL_e07910a06a086c83ba41827aa00b26ed', false),
         );
     }
 

--- a/Tests/DependencyInjection/Configuration/RedisEnvDsnTest.php
+++ b/Tests/DependencyInjection/Configuration/RedisEnvDsnTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Snc\RedisBundle\Tests\DependencyInjection\Configuration;
+
+use Snc\RedisBundle\DependencyInjection\Configuration\RedisEnvDsn;
+
+class RedisEnvDsnTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @static
+     *
+     * @return array
+     */
+    public static function isValidValues()
+    {
+        return array(
+            array('redis://localhost', false),
+            array('redis://localhost/1', false),
+            array('redis://pw@localhost:63790/10', false),
+            array('redis://127.0.0.1', false),
+            array('redis://127.0.0.1/1', false),
+            array('redis://pw@127.0.0.1:63790/10', false),
+            array('redis:///redis.sock', false),
+            array('redis:///redis.sock/1', false),
+            array('redis://pw@/redis.sock/10', false),
+            array('redis://pw@/redis.sock/10', false),
+            array('redis://%redis_host%', false),
+            array('redis://%redis_host%/%redis_db%', false),
+            array('redis://%redis_host%:%redis_port%', false),
+            array('redis://%redis_host%:%redis_port%/%redis_db%', false),
+            array('redis://%redis_pass%@%redis_host%:%redis_port%/%redis_db%', false),
+            array('redis://env_REDIS_HOST_1ef60d9ef7a55747f99d0a42206e58ed', false),
+            array('redis://env_REDIS_HOST_1ef60d9ef7a55747f99d0a42206e58ed/env_REDIS_DB_0d1da5bfb707f91e21a1f78cd11fcd0a', false),
+            array('redis://env_REDIS_HOST_1ef60d9ef7a55747f99d0a42206e58ed:env_REDIS_PORT_0458150d4bf631c8ac63b0fa4d257a21', false),
+            array('redis://env_REDIS_HOST_1ef60d9ef7a55747f99d0a42206e58ed:env_REDIS_PORT_0458150d4bf631c8ac63b0fa4d257a21/env_REDIS_DB_0d1da5bfb707f91e21a1f78cd11fcd0a', false),
+            array('redis://env_REDIS_PW_e7406513a853fd4692343d101baecb7c@env_REDIS_HOST_1ef60d9ef7a55747f99d0a42206e58ed:env_REDIS_PORT_0458150d4bf631c8ac63b0fa4d257a21/env_REDIS_DB_0d1da5bfb707f91e21a1f78cd11fcd0a', false),
+            array('localhost', false),
+            array('localhost/1', false),
+            array('pw@localhost:63790/10', false),
+            array('env_REDIS_URL_z07910a06a086c83ba41827aa00b26ed', false),
+            array('env_REDIS_URL_e07910a06a086c83ba41827aa00b26ed', true),
+        );
+    }
+
+    /**
+     * @param string $dsn   DSN
+     * @param bool   $valid Valid
+     *
+     * @dataProvider isValidValues
+     */
+    public function testIsValid($dsn, $valid)
+    {
+        $dsn = new RedisEnvDsn($dsn);
+        $this->assertSame($valid, $dsn->isValid());
+    }
+
+    /**
+     * @param string $dsn DSN
+     *
+     * @dataProvider isValidValues
+     */
+    public function testAliasIsNull($dsn)
+    {
+        $dsn = new RedisEnvDsn($dsn);
+        $this->assertNull($dsn->getAlias());
+    }
+
+    /**
+     * @param string $dsn DSN
+     *
+     * @dataProvider isValidValues
+     */
+    public function testDsnIsUnmodified($providedDsn)
+    {
+        $dsn = new RedisEnvDsn($providedDsn);
+        $this->assertEquals($providedDsn, $dsn->getDsn());
+    }
+}

--- a/Tests/DependencyInjection/SncRedisExtensionEnvTest.php
+++ b/Tests/DependencyInjection/SncRedisExtensionEnvTest.php
@@ -1,0 +1,185 @@
+<?php
+
+namespace Snc\RedisBundle\Tests\DependencyInjection;
+
+use Snc\RedisBundle\DependencyInjection\SncRedisExtension;
+use Symfony\Component\DependencyInjection\Compiler\MergeExtensionConfigurationPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\ParameterBag\EnvPlaceholderParameterBag;
+use Symfony\Component\HttpKernel\Kernel;
+use Symfony\Component\Yaml\Parser;
+
+/**
+ * SncRedisExtensionTest
+ */
+class SncRedisExtensionEnvTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @see http://symfony.com/blog/new-in-symfony-3-2-runtime-environment-variables
+     */
+    protected function setUp()
+    {
+        if (version_compare(Kernel::VERSION, '3.2.0', '<')) {
+            $this->markTestSkipped(
+                'env() style parameters are supported from Symfony 3.2.0 onwards.'
+            );
+        }
+    }
+
+    /**
+     * @static
+     *
+     * @return array
+     */
+    public static function parameterValues()
+    {
+        return array(
+            array('snc_redis.client.class', 'Predis\Client'),
+            array('snc_redis.client_options.class', 'Predis\Configuration\Options'),
+            array('snc_redis.connection_parameters.class', 'Predis\Connection\Parameters'),
+            array('snc_redis.connection_factory.class', 'Snc\RedisBundle\Client\Predis\Connection\ConnectionFactory'),
+            array('snc_redis.connection_wrapper.class', 'Snc\RedisBundle\Client\Predis\Connection\ConnectionWrapper'),
+            array('snc_redis.logger.class', 'Snc\RedisBundle\Logger\RedisLogger'),
+            array('snc_redis.data_collector.class', 'Snc\RedisBundle\DataCollector\RedisDataCollector'),
+            array('snc_redis.doctrine_cache_phpredis.class', 'Doctrine\Common\Cache\RedisCache'),
+            array('snc_redis.doctrine_cache_predis.class', 'Doctrine\Common\Cache\PredisCache'),
+            array('snc_redis.monolog_handler.class', 'Monolog\Handler\RedisHandler'),
+            array('snc_redis.swiftmailer_spool.class', 'Snc\RedisBundle\SwiftMailer\RedisSpool'),
+        );
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
+     */
+    public function testEmptyConfigLoad()
+    {
+        $extension = new SncRedisExtension();
+        $config = array();
+        $extension->load(array($config), $this->getContainer());
+    }
+
+    /**
+     * @param string $name     Name
+     * @param string $expected Expected value
+     *
+     * @dataProvider parameterValues
+     */
+    public function testDefaultParameterConfigLoad($name, $expected)
+    {
+        $container = $this->getConfiguredContainer($this->getMinimalYamlConfig());
+
+        $this->assertEquals($expected, $container->getParameter($name));
+    }
+
+    /**
+     * @param string $name     Name
+     * @param string $expected Expected value
+     *
+     * @dataProvider parameterValues
+     */
+    public function testDefaultClientTaggedServicesConfigLoad($name, $expected)
+    {
+        $container = $this->getConfiguredContainer($this->getMinimalYamlConfig());
+
+        $this->assertInternalType('array', $container->findTaggedServiceIds('snc_redis.client'));
+        $this->assertCount(1, $container->findTaggedServiceIds('snc_redis.client'), 'Minimal Yaml should have tagged 1 client');
+    }
+
+    /**
+     * Test loading of minimal config
+     */
+    public function testMinimalConfigLoad()
+    {
+        $container = $this->getConfiguredContainer($this->getMinimalYamlConfig());
+
+        $this->assertTrue($container->hasDefinition('snc_redis.logger'));
+        $this->assertTrue($container->hasDefinition('snc_redis.data_collector'));
+
+        $this->assertTrue($container->hasDefinition('snc_redis.connection.default_parameters.default'));
+        $this->assertTrue($container->hasDefinition('snc_redis.client.default_profile'));
+        $this->assertTrue($container->hasDefinition('snc_redis.client.default_options'));
+        $this->assertTrue($container->hasDefinition('snc_redis.default'));
+        $this->assertTrue($container->hasAlias('snc_redis.default_client'));
+        $this->assertInternalType('array', $container->findTaggedServiceIds('snc_redis.client'));
+        $this->assertEquals(array('snc_redis.default' => array(array('alias' => 'default'))), $container->findTaggedServiceIds('snc_redis.client'));
+    }
+
+    /**
+     * Test valid config of the cluster option
+     */
+    public function testClusterOption()
+    {
+        $container = $this->getConfiguredContainer($this->getClusterYamlConfig());
+
+        $options = $container->getDefinition('snc_redis.client.default_options')->getArgument(0);
+        $this->assertEquals('redis', $options['cluster']);
+        $this->assertFalse(array_key_exists('replication', $options));
+
+        $parameters = $container->getDefinition('snc_redis.default')->getArgument(0);
+        $this->assertEquals('snc_redis.connection.default1_parameters.default', (string) $parameters[0]);
+        $this->assertEquals('snc_redis.connection.default2_parameters.default', (string) $parameters[1]);
+
+        $this->assertInternalType('array', $container->findTaggedServiceIds('snc_redis.client'));
+        $this->assertEquals(array('snc_redis.default' => array(array('alias' => 'default'))), $container->findTaggedServiceIds('snc_redis.client'));
+    }
+
+    private function parseYaml($yaml)
+    {
+        $parser = new Parser();
+
+        return $parser->parse($yaml);
+    }
+
+    private function getMinimalYamlConfig()
+    {
+        return <<<'EOF'
+clients:
+    default:
+        type: predis
+        alias: default
+        dsn: "%env(REDIS_URL)%"
+EOF;
+    }
+
+    public function getClusterYamlConfig()
+    {
+        return <<<'EOF'
+clients:
+    default:
+        type: predis
+        alias: default
+        dsn:
+            - "%env(REDIS_URL_1)%"
+            - "%env(REDIS_URL_2)%"
+        options:
+            cluster: "redis"
+EOF;
+    }
+
+    private function getContainer()
+    {
+        return new ContainerBuilder(new EnvPlaceholderParameterBag(array(
+            'kernel.debug' => false,
+            'kernel.bundles' => array(),
+            'kernel.cache_dir' => sys_get_temp_dir(),
+            'kernel.environment' => 'test',
+            'kernel.root_dir' => __DIR__ . '/../../'
+        )));
+    }
+
+    private function getConfiguredContainer($yaml)
+    {
+        $extension = new SncRedisExtension();
+        $config = $this->parseYaml($yaml);
+
+        $container = $this->getContainer();
+
+        $container->registerExtension($extension);
+        $container->prependExtensionConfig($extension->getAlias(), $config);
+
+        $pass = new MergeExtensionConfigurationPass();
+        $pass->process($container);
+
+        return $container;
+    }
+}

--- a/Tests/Factory/EnvParametersFactoryTest.php
+++ b/Tests/Factory/EnvParametersFactoryTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Snc\RedisBundle\Tests\Factory;
+
+use Snc\RedisBundle\Factory\EnvParametersFactory;
+
+class EnvParametersFactoryTest extends \PHPUnit_Framework_TestCase
+{
+    public function createDp()
+    {
+        return array(
+            array(
+                'redis://z:df577d779b4f724c8c29b5eff5bcc534b732722b9df308a661f1b79014175063d5@ec2-34-321-123-45.us-east-1.compute.amazonaws.com:3210',
+                'Predis\Connection\Parameters',
+                array(
+                    'test' => 123,
+                    'some' => 'string',
+                    'arbitrary' => true,
+                    'values' => array(1, 2, 3)
+                )
+            ),
+            array(
+                'redis://password@host:4711',
+                'Predis\Connection\Parameters',
+                array()
+            )
+        );
+    }
+
+    /**
+     * @param $dsn
+     * @param $class
+     * @param $options
+     *
+     * @dataProvider createDp
+     */
+    public function testCreate($dsn, $class, $options)
+    {
+        $parameters = EnvParametersFactory::create($options, $class, $dsn);
+
+        $this->assertInstanceOf($class, $parameters);
+
+        foreach ($options as $optionName => $optionValue) {
+            $this->assertEquals($optionValue, $parameters->{$optionName});
+        }
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testCreateException()
+    {
+        EnvParametersFactory::create(array(), '\stdClass', 'redis://localhost');
+    }
+}


### PR DESCRIPTION
Being affected by the issue described in #302 I looked into what needs to be done to support Heroku's REDIS_URL environment variables. In short, they provide the credentials to a booked Redis addon via an environment variable which might change anytime at their discretion:

> In order for Heroku to manage this add-on for you and respond to a variety of operational situations, the REDIS config vars may change at any time. Relying on the config var outside of your Heroku app may result in you having to re-copy the value if it changes.
> -- *https://devcenter.heroku.com/articles/heroku-redis#create-a-new-instance*

Therefor I just wanted to be able to make use of the `env()` dynamic parameter notation as in

```yaml
snc_redis:
    session:
        client: session
    clients:
        session:
            type:  predis
            alias: session
            dsn:  "%env(REDIS_URL)%"
```

I came up with a rather simple approach which basically boils down to:
- detect the specific syntax while the container compiles and bypass the validation on compilation
- assemble the service with the help of a Factory which parsed the url at runtime
- merge parsed url fragments with the rest of the connection options and then instantiates the Predis client as usual
