### PR TITLE
Fix ci warning caused by PHPUnit Api deprecation

### DIFF
--- a/Tests/CommandTestCase.php
+++ b/Tests/CommandTestCase.php
@@ -47,7 +47,7 @@ abstract class CommandTestCase extends \PHPUnit_Framework_TestCase
      */
     public function setUp()
     {
-        $this->container = $this->getMock('\\Symfony\\Component\\DependencyInjection\\ContainerInterface');
+        $this->container = $this->getMockBuilder('\\Symfony\\Component\\DependencyInjection\\ContainerInterface')->getMock();
 
         $kernel = $this->getMockBuilder('\\Symfony\\Component\\HttpKernel\\Kernel')
             ->disableOriginalConstructor()
@@ -60,7 +60,7 @@ abstract class CommandTestCase extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue($this->container));
         $this->application = new Application($kernel);
 
-        $this->predisClient = $this->getMock('\\Predis\\Client');
+        $this->predisClient = $this->getMockBuilder('\\Predis\\Client')->getMock();
 
         $this->phpredisClient = $this->getMockBuilder('PhpredisClient')
             ->disableOriginalConstructor()
@@ -73,7 +73,7 @@ abstract class CommandTestCase extends \PHPUnit_Framework_TestCase
 
     protected function registerPredisClient()
     {
-        $this->predisClient = $this->getMock('\\Predis\\Client');
+        $this->predisClient = $this->getMockBuilder('\\Predis\\Client')->getMock();
 
         $this->container->expects($this->once())
             ->method('get')

--- a/Tests/Logger/RedisLoggerTest.php
+++ b/Tests/Logger/RedisLoggerTest.php
@@ -24,7 +24,7 @@ class RedisLoggerTest extends \PHPUnit_Framework_TestCase
             $this->markTestSkipped('PSR-3 logger package is not installed.');
         }
 
-        $this->logger = $this->getMock('Psr\Log\LoggerInterface');
+        $this->logger = $this->getMockBuilder('Psr\Log\LoggerInterface')->getMock();
         $this->redisLogger = new RedisLogger($this->logger);
     }
 
@@ -34,7 +34,7 @@ class RedisLoggerTest extends \PHPUnit_Framework_TestCase
             $this->markTestSkipped('The Symfony LoggerInterface is not available as Symfony 3+ is installed.');
         }
 
-        $this->logger = $this->getMock('Symfony\Component\HttpKernel\Log\LoggerInterface');
+        $this->logger = $this->getMockBuilder('Symfony\Component\HttpKernel\Log\LoggerInterface')->getMock();
         $this->redisLogger = new RedisLogger($this->logger);
     }
 

--- a/Tests/Session/Storage/Handler/RedisSessionHandlerTest.php
+++ b/Tests/Session/Storage/Handler/RedisSessionHandlerTest.php
@@ -22,7 +22,10 @@ class RedisSessionHandlerTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->redis = $this->getMock('Predis\Client', array('get', 'set', 'setex', 'del'));
+        $this->redis = $this
+            ->getMockBuilder('Predis\Client')
+            ->setMethods(array('get', 'set', 'setex', 'del'))
+            ->getMock();
     }
 
     protected function tearDown()


### PR DESCRIPTION
`getMock()`is deprecated since PHPUnit 5.4.0.

Fix warnings in PR https://github.com/snc/SncRedisBundle/pull/370