### PR TITLE
Protect against session fixation attacks

### DIFF
--- a/Tests/Session/Storage/Handler/RedisSessionHandlerTest.php
+++ b/Tests/Session/Storage/Handler/RedisSessionHandlerTest.php
@@ -24,7 +24,7 @@ class RedisSessionHandlerTest extends \PHPUnit_Framework_TestCase
     {
         $this->redis = $this
             ->getMockBuilder('Predis\Client')
-            ->setMethods(array('get', 'set', 'setex', 'del'))
+            ->setMethods(array('get', 'set', 'setex', 'del', 'exists'))
             ->getMock();
     }
 
@@ -33,12 +33,24 @@ class RedisSessionHandlerTest extends \PHPUnit_Framework_TestCase
         unset($this->redis);
     }
 
-    public function testSessionReading()
+    public function testSessionReadingWithStrictModeDisabled()
     {
         $this->redis
             ->expects($this->once())
             ->method('get')
             ->with($this->equalTo('_symfony'))
+        ;
+
+        $handler = new RedisSessionHandler($this->redis, array('use_strict_mode' => false), null, false);
+        $handler->read('_symfony');
+    }
+
+    public function testSessionReadingWithStrictModeEnabled()
+    {
+        $this->redis
+            ->expects($this->once())
+            ->method('get')
+            ->with($this->logicalNot($this->equalTo('_symfony')));
         ;
 
         $handler = new RedisSessionHandler($this->redis, array(), null, false);
@@ -112,7 +124,7 @@ class RedisSessionHandlerTest extends \PHPUnit_Framework_TestCase
         ;
 
         // We prepare our handlers
-        $handler = new RedisSessionHandler($this->redis, array(), 'session', true, 1000000);
+        $handler = new RedisSessionHandler($this->redis, array('use_strict_mode' => false), 'session', true, 1000000);
 
         // The first will set the lock and the second will loop until it's free
         $handler->read('_symfony_locktest');


### PR DESCRIPTION
Sometimes, a malicious user will tamper the session cookie to inject a controlled session id.
Without this protection, the session handler tries to read a session value with this session id and, if the id is not found, a new session entry is created using the malicious id.
To avoid that the PHP team introduced the use_strict_mode option in the native sessions module.
This commit introduces the use of the use_strict_mode option in the SessionHandler to prevent session fixation by issuing a new session id for the current session when an unknown session
id is used.
For the sake of facility, we rely only on the opened sessions to conclude whether or not the session id is known.
We could add opened session ids history as in https://github.com/1ma/RedisSessionHandler
but I can't see any useful use case for now.

PR review appreciated