### PR TITLE
Updated test with namespaced PHPUnit TestCase

### DIFF
--- a/Tests/Client/Phpredis/ClientTest.php
+++ b/Tests/Client/Phpredis/ClientTest.php
@@ -3,11 +3,12 @@
 namespace Snc\RedisBundle\Tests\Client\Phpredis;
 
 use Snc\RedisBundle\Client\Phpredis\Client;
+use PHPUnit\Framework\TestCase;
 
 /**
  * ClientTest
  */
-class ClientTest extends \PHPUnit_Framework_TestCase
+class ClientTest extends TestCase
 {
     /**
      * @covers \Snc\RedisBundle\Client\Phpredis\Client::getCommandString

--- a/Tests/CommandTestCase.php
+++ b/Tests/CommandTestCase.php
@@ -13,13 +13,14 @@ namespace Snc\RedisBundle\Tests;
 
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Snc\RedisBundle\Client\Phpredis\Client as PhpredisClient;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Base Class for command tests
  *
  * @author Sebastian Göttschkes <sebastian.goettschkes@googlemail.com>
  */
-abstract class CommandTestCase extends \PHPUnit_Framework_TestCase
+abstract class CommandTestCase extends TestCase
 {
 
     /**

--- a/Tests/DependencyInjection/Configuration/RedisDsnTest.php
+++ b/Tests/DependencyInjection/Configuration/RedisDsnTest.php
@@ -12,11 +12,12 @@
 namespace Snc\RedisBundle\Tests\DependencyInjection\Configuration;
 
 use Snc\RedisBundle\DependencyInjection\Configuration\RedisDsn;
+use PHPUnit\Framework\TestCase;
 
 /**
  * RedisDsnTest
  */
-class RedisDsnTest extends \PHPUnit_Framework_TestCase
+class RedisDsnTest extends TestCase
 {
     /**
      * @static

--- a/Tests/DependencyInjection/SncRedisExtensionEnvTest.php
+++ b/Tests/DependencyInjection/SncRedisExtensionEnvTest.php
@@ -8,11 +8,12 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ParameterBag\EnvPlaceholderParameterBag;
 use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\Yaml\Parser;
+use PHPUnit\Framework\TestCase;
 
 /**
  * SncRedisExtensionTest
  */
-class SncRedisExtensionEnvTest extends \PHPUnit_Framework_TestCase
+class SncRedisExtensionEnvTest extends TestCase
 {
     /**
      * @see http://symfony.com/blog/new-in-symfony-3-2-runtime-environment-variables

--- a/Tests/DependencyInjection/SncRedisExtensionTest.php
+++ b/Tests/DependencyInjection/SncRedisExtensionTest.php
@@ -21,11 +21,12 @@ use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 use Symfony\Component\Yaml\Parser;
+use PHPUnit\Framework\TestCase;
 
 /**
  * SncRedisExtensionTest
  */
-class SncRedisExtensionTest extends \PHPUnit_Framework_TestCase
+class SncRedisExtensionTest extends TestCase
 {
     /**
      * @static
@@ -255,6 +256,8 @@ class SncRedisExtensionTest extends \PHPUnit_Framework_TestCase
 
     /**
      * Test valid XML config
+     *
+     * @doesNotPerformAssertions
      */
     public function testValidXmlConfig()
     {

--- a/Tests/Extra/RateLimitTest.php
+++ b/Tests/Extra/RateLimitTest.php
@@ -12,13 +12,14 @@
 namespace Snc\RedisBundle\Tests\Extra;
 
 use Snc\RedisBundle\Extra\RateLimit;
+use PHPUnit\Framework\TestCase;
 
 /**
  * RateLimitTest.
  *
  * @author Pierre Boudelle <pierre.boudelle@gmail.com>
  */
-class RateLimitTest extends \PHPUnit_Framework_TestCase
+class RateLimitTest extends TestCase
 {
     protected $_redis;
 

--- a/Tests/Logger/RedisLoggerTest.php
+++ b/Tests/Logger/RedisLoggerTest.php
@@ -12,8 +12,9 @@
 namespace Snc\RedisBundle\Tests\Logger;
 
 use Snc\RedisBundle\Logger\RedisLogger;
+use PHPUnit\Framework\TestCase;
 
-class RedisLoggerTest extends \PHPUnit_Framework_TestCase
+class RedisLoggerTest extends TestCase
 {
     private $logger;
     private $redisLogger;
@@ -93,6 +94,9 @@ class RedisLoggerTest extends \PHPUnit_Framework_TestCase
         ), $this->redisLogger->getCommands());
     }
 
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testLogSuccessfulCommandWithoutLogger()
     {
         $redisLogger = new RedisLogger();
@@ -100,6 +104,9 @@ class RedisLoggerTest extends \PHPUnit_Framework_TestCase
         $redisLogger->logCommand('foo', 10, 'connection');
     }
 
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testLogFailedCommandWithoutLogger()
     {
         $redisLogger = new RedisLogger();

--- a/Tests/Profiler/Storage/RedisProfilerStorageTest.php
+++ b/Tests/Profiler/Storage/RedisProfilerStorageTest.php
@@ -14,8 +14,9 @@ namespace Symfony\Component\HttpKernel\Tests\Profiler;
 use Snc\RedisBundle\Profiler\Storage\RedisProfilerStorage;
 use Snc\RedisBundle\Tests\Profiler\Storage\Mock\RedisMock;
 use Symfony\Component\HttpKernel\Profiler\Profile;
+use PHPUnit\Framework\TestCase;
 
-class RedisProfilerStorageTest extends \PHPUnit_Framework_TestCase
+class RedisProfilerStorageTest extends TestCase
 {
     protected static $storage;
 

--- a/Tests/Session/Storage/Handler/RedisSessionHandlerTest.php
+++ b/Tests/Session/Storage/Handler/RedisSessionHandlerTest.php
@@ -12,11 +12,12 @@
 namespace Snc\RedisBundle\Tests\Session\Storage\Handler;
 
 use Snc\RedisBundle\Session\Storage\Handler\RedisSessionHandler;
+use PHPUnit\Framework\TestCase;
 
 /**
  * RedisSessionHandlerTest
  */
-class RedisSessionHandlerTest extends \PHPUnit_Framework_TestCase
+class RedisSessionHandlerTest extends TestCase
 {
     private $redis;
 

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "predis/predis": "^1.0",
         "symfony/console": "^2.7 || ^3.0 || ^4.0",
         "symfony/phpunit-bridge": "^2.7 || ^3.0 || ^4.0",
-        "phpunit/phpunit": "^4.8 || ^5.4"
+        "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5"
     },
     "suggest": {
         "monolog/monolog": "If you want to use the monolog redis handler.",


### PR DESCRIPTION
PR makes unit tests extending namespaced `TestCase` rather than `PHPUnit_Framework_TestCase`. This change enables upgrade of PHPUnit to v6, with minimum version of `4.8.35` where compatibility layer was introduced.