### PR TITLE
fix predis logging using symfony cache component

### DIFF
--- a/Client/Predis/Connection/ConnectionWrapper.php
+++ b/Client/Predis/Connection/ConnectionWrapper.php
@@ -95,7 +95,16 @@ class ConnectionWrapper implements NodeConnectionInterface
      */
     public function writeRequest(CommandInterface $command)
     {
-        return $this->connection->writeRequest($command);
+        if (null === $this->logger) {
+            $this->connection->writeRequest($command);
+            return;
+        }
+
+        $startTime = microtime(true);
+        $this->connection->writeRequest($command);
+        $duration = (microtime(true) - $startTime) * 1000;
+
+        $this->logger->logCommand($this->commandToString($command), $duration, $this->getParameters()->alias);
     }
 
     /**


### PR DESCRIPTION
#407 

Well, i went deeper and found the problem
![bdc424d677_ready](https://user-images.githubusercontent.com/2445241/38429535-51c755ba-39c7-11e8-9cf0-d7b02f46cc72.png)

It seems that duration is not correct because it doesn't wait for response for the pipeline (as symfony adapters do) ... maybe maiterners will inlarge logger to support it ... 

PS
I've created PR branch from tag 2.0.6 not master