### PR TITLE
Make all bundle services private

### DIFF
--- a/DependencyInjection/SncRedisExtension.php
+++ b/DependencyInjection/SncRedisExtension.php
@@ -201,7 +201,7 @@ class SncRedisExtension extends Extension
         $optionDef->addArgument($client['options']);
         $container->setDefinition($optionId, $optionDef);
         $clientDef = new Definition($container->getParameter('snc_redis.client.class'));
-        $clientDef->setPublic(true);
+        $clientDef->setPublic(false);
         $clientDef->addTag('snc_redis.client', array('alias' => $client['alias']));
         if (1 === $connectionCount) {
             $clientDef->addArgument(new Reference(sprintf('snc_redis.connection.%s_parameters.%s', $connectionAliases[0], $client['alias'])));

--- a/Resources/config/profiler_storage.xml
+++ b/Resources/config/profiler_storage.xml
@@ -11,7 +11,7 @@
     </parameters>
 
     <services>
-        <service id="profiler.storage" class="%snc_redis.profiler_storage.class%">
+        <service id="profiler.storage" class="%snc_redis.profiler_storage.class%" public="false">
             <argument type="service" id="snc_redis.profiler_storage.client" />
             <argument>%snc_redis.profiler_storage.ttl%</argument>
         </service>

--- a/Resources/config/redis.xml
+++ b/Resources/config/redis.xml
@@ -7,7 +7,7 @@
     http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
-        <service id="snc_redis.logger" class="%snc_redis.logger.class%">
+        <service id="snc_redis.logger" class="%snc_redis.logger.class%" public="false">
             <tag name="monolog.logger" channel="snc_redis" />
             <argument type="service" id="logger" on-invalid="null" />
         </service>
@@ -16,10 +16,10 @@
             <tag name="data_collector" template="@SncRedis/Collector/redis.html.twig" id="redis" />
             <argument type="service" id="snc_redis.logger" />
         </service>
-        <service id="snc_redis.command.flush_all" class="Snc\RedisBundle\Command\RedisFlushallCommand">
+        <service id="snc_redis.command.flush_all" class="Snc\RedisBundle\Command\RedisFlushallCommand" public="false">
             <tag name="console.command" command="redis:flushall" />
         </service>
-        <service id="snc_redis.command.flush_db" class="Snc\RedisBundle\Command\RedisFlushdbCommand">
+        <service id="snc_redis.command.flush_db" class="Snc\RedisBundle\Command\RedisFlushdbCommand" public="false">
             <tag name="console.command" command="redis:flushdb" />
         </service>
     </services>

--- a/Resources/config/session.xml
+++ b/Resources/config/session.xml
@@ -11,7 +11,7 @@
     </parameters>
 
     <services>
-        <service id="snc_redis.session.handler" class="%snc_redis.session.handler.class%">
+        <service id="snc_redis.session.handler" class="%snc_redis.session.handler.class%" public="false">
             <argument type="service" id="snc_redis.session.client" />
             <argument>%session.storage.options%</argument>
             <argument>%snc_redis.session.prefix%</argument>


### PR DESCRIPTION
Since Symfony 3.4 recommended practice is to keep all services private
and use declarative dependency injection.

Closes #384