### PR TITLE
Add Serialization option

### DIFF
--- a/DependencyInjection/Configuration/Configuration.php
+++ b/DependencyInjection/Configuration/Configuration.php
@@ -114,6 +114,7 @@ class Configuration implements ConfigurationInterface
                                     ->scalarNode('read_write_timeout')->defaultNull()->end()
                                     ->booleanNode('iterable_multibulk')->defaultFalse()->end()
                                     ->booleanNode('throw_errors')->defaultTrue()->end()
+                                    ->scalarNode('serialization')->defaultValue("default")->end()
                                     ->scalarNode('profile')->defaultValue('default')
                                     ->end()
                                     ->scalarNode('cluster')->defaultNull()->end()

--- a/DependencyInjection/Configuration/Configuration.php
+++ b/DependencyInjection/Configuration/Configuration.php
@@ -114,7 +114,7 @@ class Configuration implements ConfigurationInterface
                                     ->scalarNode('read_write_timeout')->defaultNull()->end()
                                     ->booleanNode('iterable_multibulk')->defaultFalse()->end()
                                     ->booleanNode('throw_errors')->defaultTrue()->end()
-                                    ->scalarNode('serialization')->defaultValue("default")->end()
+                                    ->scalarNode('serialization')->defaultValue('default')->end()
                                     ->scalarNode('profile')->defaultValue('default')
                                     ->end()
                                     ->scalarNode('cluster')->defaultNull()->end()

--- a/DependencyInjection/SncRedisExtension.php
+++ b/DependencyInjection/SncRedisExtension.php
@@ -442,11 +442,10 @@ class SncRedisExtension extends Extension
      */
     public function loadSerializationType($type)
     {
-        // not using constants, because it would fail if phpredis extension is not enabled
         $types = array(
-            'none' => 0, // \Redis::SERIALIZER_NONE,
-            'php' => 1,  // \Redis::SERIALIZER_PHP,
-            'igbinary' => 2 // \Redis::SERIALIZER_IGBINARY
+            'none' => \Redis::SERIALIZER_NONE,
+            'php' => \Redis::SERIALIZER_PHP,
+            'igbinary' => \Redis::SERIALIZER_IGBINARY
         );
 
         // allow user to pass in default serialization in which case we should automatically decide for them

--- a/DependencyInjection/SncRedisExtension.php
+++ b/DependencyInjection/SncRedisExtension.php
@@ -444,17 +444,13 @@ class SncRedisExtension extends Extension
     {
         // not using constants, because it would fail if phpredis extension is not enabled
         $types = array(
-            "none" => 0, // \Redis::SERIALIZER_NONE,
-            "php" => 1,  // \Redis::SERIALIZER_PHP,
-            "igbinary" => 2 // \Redis::SERIALIZER_IGBINARY
+            'none' => 0, // \Redis::SERIALIZER_NONE,
+            'php' => 1,  // \Redis::SERIALIZER_PHP,
+            'igbinary' => 2 // \Redis::SERIALIZER_IGBINARY
         );
 
         // allow user to pass in default serialization in which case we should automatically decide for them
         if ('default' == $type) {
-            if (defined('HHVM_VERSION')) {
-                return $types['php'];
-            }
-
             return defined('Redis::SERIALIZER_IGBINARY') ? $types['igbinary'] : $types['php'];
         } elseif (array_key_exists($type, $types)) {
             return $types[$type];

--- a/DependencyInjection/SncRedisExtension.php
+++ b/DependencyInjection/SncRedisExtension.php
@@ -453,7 +453,7 @@ class SncRedisExtension extends Extension
 
         // allow user to pass in default serialization in which case we should automatically decide for them
         if ('default' == $type) {
-            return $types['igbinary'] ?? $types['php'];
+            return isset($types['igbinary']) ? $types['igbinary'] : $types['php'];
         } elseif (array_key_exists($type, $types)) {
             return $types[$type];
         }

--- a/DependencyInjection/SncRedisExtension.php
+++ b/DependencyInjection/SncRedisExtension.php
@@ -444,13 +444,16 @@ class SncRedisExtension extends Extension
     {
         $types = array(
             'none' => \Redis::SERIALIZER_NONE,
-            'php' => \Redis::SERIALIZER_PHP,
-            'igbinary' => \Redis::SERIALIZER_IGBINARY
+            'php' => \Redis::SERIALIZER_PHP
         );
+
+        if (defined('Redis::SERIALIZER_IGBINARY')) {
+            $types['igbinary'] = \Redis::SERIALIZER_IGBINARY;
+        }
 
         // allow user to pass in default serialization in which case we should automatically decide for them
         if ('default' == $type) {
-            return defined('Redis::SERIALIZER_IGBINARY') ? $types['igbinary'] : $types['php'];
+            return $types['igbinary'] ?? $types['php'];
         } elseif (array_key_exists($type, $types)) {
             return $types[$type];
         }

--- a/Resources/config/schema/redis-1.0.xsd
+++ b/Resources/config/schema/redis-1.0.xsd
@@ -56,11 +56,21 @@
         <xsd:attribute name="read-write-timeout" type="xsd:int" />
         <xsd:attribute name="iterable-multibulk" type="xsd:boolean" />
         <xsd:attribute name="throw-errors" type="xsd:boolean" />
+        <xsd:attribute name="serialization" type="phpredis-serialization-type" />
         <xsd:attribute name="profile" type="client-profile" />
         <xsd:attribute name="cluster" type="xsd:string" />
         <xsd:attribute name="prefix" type="xsd:string" />
         <xsd:attribute name="replication" type="xsd:boolean" />
     </xsd:complexType>
+
+    <xsd:simpleType name="phpredis-serialization-type">
+        <xsd:restriction base="xsd:string">
+            <xsd:enumeration value="default" />
+            <xsd:enumeration value="none" />
+            <xsd:enumeration value="php" />
+            <xsd:enumeration value="igbinary" />
+        </xsd:restriction>
+    </xsd:simpleType>
 
     <xsd:simpleType name="client-profile">
         <xsd:restriction base="xsd:string">

--- a/Tests/DependencyInjection/SncRedisExtensionTest.php
+++ b/Tests/DependencyInjection/SncRedisExtensionTest.php
@@ -309,6 +309,41 @@ class SncRedisExtensionTest extends TestCase
     }
 
     /**
+     * Test valid config of the serialization option
+     */
+    public function testClientSerializationOption()
+    {
+         $extension = new SncRedisExtension();
+         $config = $this->parseYaml($this->getSerializationYamlConfig());
+         $extension->load(array($config), $container = $this->getContainer());
+         $options = $container->getDefinition('snc_redis.client.default_options')->getArgument(0);
+         $parameters = $container->getDefinition('snc_redis.default')->getArgument(0);
+         $masterParameters = $container->getDefinition((string) $parameters[0])->getArgument(0);
+         $this->assertSame($options['serialization'], $masterParameters['serialization']);
+    }
+
+    /**
+     * Test validity of serialization type
+     */
+    public function testLoadSerializationType()
+    {
+        $extension = new SncRedisExtension();
+        $config = $this->parseYaml($this->getSerializationYamlConfig());
+        $extension->load(array($config), $container = $this->getContainer());
+        $options = $container->getDefinition('snc_redis.client.default_options')->getArgument(0);
+        $serializationType = $extension->loadSerializationType($options['serialization']);
+        $this->assertTrue(is_integer($serializationType));
+
+        if (defined('HHVM_VERSION')) {
+            $defaultType = 1;
+        } else {
+            $defaultType = defined('Redis::SERIALIZER_IGBINARY') ? 2 : 1;
+        }
+
+        $this->assertEquals($defaultType, $serializationType);
+    }
+
+    /**
      * Test valid config of the sentinel replication option
      */
     public function testSentinelOption()
@@ -359,6 +394,21 @@ class SncRedisExtensionTest extends TestCase
         $parser = new Parser();
 
         return $parser->parse($yaml);
+    }
+
+    private function getSerializationYamlConfig()
+     {
+         return <<<'EOF'
+clients:
+ default:
+     type: predis
+     alias: default
+     dsn:
+         - redis://localhost?alias=master
+         - redis://otherhost
+     options:
+         serialization: "default"
+EOF;
     }
 
     private function getMinimalYamlConfig()

--- a/Tests/DependencyInjection/SncRedisExtensionTest.php
+++ b/Tests/DependencyInjection/SncRedisExtensionTest.php
@@ -334,11 +334,7 @@ class SncRedisExtensionTest extends TestCase
         $serializationType = $extension->loadSerializationType($options['serialization']);
         $this->assertTrue(is_integer($serializationType));
 
-        if (defined('HHVM_VERSION')) {
-            $defaultType = 1;
-        } else {
-            $defaultType = defined('Redis::SERIALIZER_IGBINARY') ? 2 : 1;
-        }
+        $defaultType = defined('Redis::SERIALIZER_IGBINARY') ? 2 : 1;
 
         $this->assertEquals($defaultType, $serializationType);
     }


### PR DESCRIPTION
Serialization option is necessary for setting the type of serialization
to use for redis.

This is simply a new commit with all the code taken from PR#199 using
the latest code of SncRedisBundle on branch 2.1