### PR TITLE
Use destructor to close session (partially reverted #348)

### DIFF
--- a/Session/Storage/Handler/RedisSessionHandler.php
+++ b/Session/Storage/Handler/RedisSessionHandler.php
@@ -270,7 +270,16 @@ LUA;
     /**
      * Shutdown handler, replacement for class destructor as it might not be called.
      */
-    public function shutdown() {
+    public function shutdown()
+    {
         $this->close();
+    }
+
+    /**
+     * Destructor.
+     */
+    public function __destruct()
+    {
+        $this->shutdown();
     }
 }


### PR DESCRIPTION
Registering a shutdown function to close session in PR #348 was a great idea... However removing a destructor was a terrible one.

We have a pretty heavy test suite in our app and after updating to SncRedisBundle v2.1 (which included that PR) memory usage in it just skyrocketed, PHP started crashing running out of memory.

This PR adds destructor back while also keeping a shutdown function introduced in #348. It solves the memory issue we're facing.