### PR TITLE
Close connections on shutdown

### DIFF
--- a/Resources/config/session.xml
+++ b/Resources/config/session.xml
@@ -11,7 +11,7 @@
     </parameters>
 
     <services>
-        <service id="snc_redis.session.handler" class="%snc_redis.session.handler.class%">
+        <service id="snc_redis.session.handler" class="%snc_redis.session.handler.class%" public="true">
             <argument type="service" id="snc_redis.session.client" />
             <argument>%session.storage.options%</argument>
             <argument>%snc_redis.session.prefix%</argument>

--- a/SncRedisBundle.php
+++ b/SncRedisBundle.php
@@ -32,4 +32,17 @@ class SncRedisBundle extends Bundle
         $container->addCompilerPass(new MonologPass());
         $container->addCompilerPass(new SwiftMailerPass());
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function shutdown()
+    {
+        // Close session handler connection to avoid using up all available connection slots in tests
+        if ($this->container->has('snc_redis.session.handler')) {
+            if (!method_exists($this->container, 'initialized') || $this->container->initialized('snc_redis.session.handler')) {
+                $this->container->get('snc_redis.session.handler')->close();
+            }
+        }
+    }
 }


### PR DESCRIPTION
This PR addresses issue #400.
`SncRedisBundle::shutdown()` function will be called on kernel shutdown in-between unit tests. The same solution is implemented in DoctrineBundle.

I also had to declare `snc_redis.session.handler` as a public service to be able to fetch it from container in Symfony 4+.