### PR TITLE
Create cluster connection correctly for one host

### DIFF
--- a/DependencyInjection/SncRedisExtension.php
+++ b/DependencyInjection/SncRedisExtension.php
@@ -135,6 +135,8 @@ class SncRedisExtension extends Extension
     {
         if (null === $client['options']['cluster']) {
             unset($client['options']['cluster']);
+        } else {
+            unset($client['options']['replication']);
         }
 
         // predis connection parameters have been renamed in v0.8

--- a/DependencyInjection/SncRedisExtension.php
+++ b/DependencyInjection/SncRedisExtension.php
@@ -203,7 +203,7 @@ class SncRedisExtension extends Extension
         $clientDef = new Definition($container->getParameter('snc_redis.client.class'));
         $clientDef->setPublic(true);
         $clientDef->addTag('snc_redis.client', array('alias' => $client['alias']));
-        if (1 === $connectionCount) {
+        if (1 === $connectionCount && !isset($client['options']['cluster'])) {
             $clientDef->addArgument(new Reference(sprintf('snc_redis.connection.%s_parameters.%s', $connectionAliases[0], $client['alias'])));
         } else {
             $connections = array();


### PR DESCRIPTION
Fixes #402, #267 (might also fix some other clustering issues when only one dsn is defined)

If only one dsn is defined when cluster option is passed connection instance class is incorrect (should be [Predis\Connection\Aggregate\RedisCluster](https://github.com/nrk/predis/blob/v1.1/src/Connection/Aggregate/RedisCluster.php).

The problem is that we're passing Predis\Connection\ParametersInterface as first argument to client, but we should pass array instead cause only then [Predis\Client::createConnection](https://github.com/nrk/predis/blob/v1.1/src/Client.php#L109) method will create correct connection class.

