### PR TITLE
Command executions should be logged as DEBUG instead of INFO.

### DIFF
--- a/Logger/RedisLogger.php
+++ b/Logger/RedisLogger.php
@@ -62,7 +62,7 @@ class RedisLogger
                     $this->logger->err($message);
                 }
             } else {
-                $this->logger->info('Executing command "' . $command . '"');
+                $this->logger->debug('Executing command "' . $command . '"');
             }
         }
     }

--- a/Tests/Logger/RedisLoggerTest.php
+++ b/Tests/Logger/RedisLoggerTest.php
@@ -45,7 +45,7 @@ class RedisLoggerTest extends TestCase
 
         $this->logger
             ->expects($this->once())
-            ->method('info')
+            ->method('debug')
             ->with($this->equalTo('Executing command "foo"'));
 
         $this->redisLogger->logCommand('foo', 10, 'connection');
@@ -67,7 +67,7 @@ class RedisLoggerTest extends TestCase
     {
         $this->setUpWithPsrLogger();
 
-        $this->logger->expects($this->any())->method('info');
+        $this->logger->expects($this->any())->method('debug');
 
         for ($i = 0; $i < 3; $i++) {
             $this->redisLogger->logCommand('foo'.$i, 10, 'connection');
@@ -80,7 +80,7 @@ class RedisLoggerTest extends TestCase
     {
         $this->setUpWithPsrLogger();
 
-        $this->logger->expects($this->any())->method('info');
+        $this->logger->expects($this->any())->method('debug');
         $this->logger->expects($this->any())->method('error');
 
         for ($i = 0; $i < 3; $i++) {


### PR DESCRIPTION
…ems where INFO is being used to log informative messages like 'user logged in'.A loop with redis for e.g. in a background-process will pollute the logs extremely.

(cherry picked from commit af2e3f9)

I wanted to make this change, but I found this commit in the master branch. That brings me to another question: what's the reason behind 4 different branches (master, 1.0, 1.1, 2.1)?