### PR TITLE
Add on demand phpredis connections

### DIFF
--- a/Client/Phpredis/Client.php
+++ b/Client/Phpredis/Client.php
@@ -83,7 +83,8 @@ class Client extends Redis
      */
     private function onDemandCalls()
     {
-        foreach ($this->delayedCalls as $delayedCallArr) {
+        while (!empty($this->delayedCalls)) {
+            $delayedCallArr = array_shift($this->delayedCalls);
             call_user_func_array('parent::' . $delayedCallArr['method'], $delayedCallArr['args']);
         }
         $this->onDemandPending = false;

--- a/DependencyInjection/Configuration/Configuration.php
+++ b/DependencyInjection/Configuration/Configuration.php
@@ -108,6 +108,7 @@ class Configuration implements ConfigurationInterface
                             ->arrayNode('options')
                                 ->addDefaultsIfNotSet()
                                 ->children()
+                                    ->booleanNode('on_demand_connect')->defaultFalse()->end()
                                     ->booleanNode('connection_async')->defaultFalse()->end()
                                     ->booleanNode('connection_persistent')->defaultFalse()->end()
                                     ->scalarNode('connection_timeout')->defaultValue(5)->end()

--- a/DependencyInjection/SncRedisExtension.php
+++ b/DependencyInjection/SncRedisExtension.php
@@ -294,10 +294,12 @@ class SncRedisExtension extends Extension
         }
 
         $phpredisDef = new Definition($container->getParameter('snc_redis.phpredis_client.class'));
-        if ($client['logging']) {
+        $logger = $client['logging'] ? new Reference('snc_redis.logger') : null;
+        $onDemandConnect = $client['options']['on_demand_connect'];
+        if ($logger || $onDemandConnect) {
             $phpredisDef = new Definition($container->getParameter('snc_redis.phpredis_connection_wrapper.class'));
-            $phpredisDef->addArgument(array('alias' => $client['alias']));
-            $phpredisDef->addArgument(new Reference('snc_redis.logger'));
+            $phpredisDef->addArgument(array('alias' => $client['alias'], 'on_demand_connect' => $onDemandConnect));
+            $phpredisDef->addArgument($logger);
         }
 
         $phpredisDef->addTag('snc_redis.client', array('alias' => $client['alias']));
@@ -484,7 +486,7 @@ class SncRedisExtension extends Extension
 
         if (array_key_exists($type, $types)) {
             return $types[$type];
-        }
+       }
 
         throw new InvalidConfigurationException(sprintf('%s in not a valid serializer. Valid serializers: %s', $type, implode(", ", array_keys($types))));
     }

--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -220,6 +220,23 @@ snc_redis:
             entity_manager: default
 ```
 
+### On Demand Connect ###
+Wrap the phpredis client and only connect on demand. Calls to `Redis::connect`, `Redis::pconnect`, `Redis::open`, `Redis::setOption`,  `Redis::auth`, `Redis::select`, and `Redis::close` are delayed until another method is called.
+
+``` yaml
+snc_redis:
+    clients:
+        on_demand:
+            type: phpredis
+            alias: on_demand
+            dsn: redis://localhost
+            logging: false
+            options:
+                on_demand_connect: true #default false
+                connection_persistent: true
+```
+
+
 ### Monolog logging ###
 
 You can store your logs in a redis `LIST` by adding this to your config:

--- a/Tests/DependencyInjection/SncRedisExtensionEnvTest.php
+++ b/Tests/DependencyInjection/SncRedisExtensionEnvTest.php
@@ -105,6 +105,7 @@ class SncRedisExtensionEnvTest extends TestCase
         $this->assertCount(3, $connectionArguments);
         $this->assertSame(
             array(
+                'on_demand_connect' => false,
                 'read_write_timeout' => null,
                 'iterable_multibulk' => false,
                 'serialization' => 'default',


### PR DESCRIPTION
This extends the wrapper to allow connections to be seamlessly created only when necessary.  