### PR TITLE
#434 Enable Lazy service for phpredis

### DIFF
--- a/DependencyInjection/SncRedisExtension.php
+++ b/DependencyInjection/SncRedisExtension.php
@@ -276,6 +276,7 @@ class SncRedisExtension extends Extension
         $phpredisDef->addArgument($client['alias']);
         $phpredisDef->addTag('snc_redis.client', array('alias' => $client['alias']));
         $phpredisDef->setPublic(false);
+        $phpredisDef->setLazy(true);
 
         $container->setDefinition($phpredisId, $phpredisDef);
         $container->setAlias(sprintf('snc_redis.%s', $client['alias']), new Alias($phpredisId, true));

--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -386,3 +386,14 @@ snc_redis:
         client: profiler_storage
         ttl: 3600
 ```
+
+## Troubleshooting ##
+
+If cache warmup fails for prod because a redis server is not available,
+try to install [`symfony/proxy-manager-bridge`](https://symfony.com/doc/master/service_container/lazy_services.html):
+
+``` bash
+$ composer require symfony/proxy-manager-bridge
+```
+
+Once done some services will be lazy-loaded and could prevent unwanted connection call. 

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,8 @@
     "suggest": {
         "monolog/monolog": "If you want to use the monolog redis handler.",
         "predis/predis": "If you want to use predis.",
-        "symfony/console": "If you want to use commands to interact with the redis database"
+        "symfony/console": "If you want to use commands to interact with the redis database",
+        "symfony/proxy-manager-bridge": "If you want to lazy-load some services"
     },
     "autoload": {
         "psr-4": { "Snc\\RedisBundle\\": "" }


### PR DESCRIPTION
The service will be lazy if `symfony/proxy-manager-bridge` is installed
As a consequence it will allow to warmup the cache even if Redis server is not reachable

fix #434