### PR TITLE
Fix connection via TLS (rediss://) (#444)

### DIFF
--- a/DependencyInjection/Configuration/RedisDsn.php
+++ b/DependencyInjection/Configuration/RedisDsn.php
@@ -39,6 +39,11 @@ class RedisDsn
     protected $socket;
 
     /**
+     * @var bool
+     */
+    protected $tls;
+
+    /**
      * @var int
      */
     protected $database;
@@ -115,6 +120,14 @@ class RedisDsn
     }
 
     /**
+     * @return bool
+     */
+    public function getTls()
+    {
+        return $this->tls;
+    }
+
+    /**
      * @return string
      */
     public function getAlias()
@@ -135,7 +148,7 @@ class RedisDsn
      */
     public function isValid()
     {
-        if (0 !== strpos($this->dsn, 'redis://')) {
+        if (0 !== strpos($this->dsn, 'redis://') && 0 !== strpos($this->dsn, 'rediss://')) {
             return false;
         }
 
@@ -155,7 +168,7 @@ class RedisDsn
      */
     protected function parseDsn($dsn)
     {
-        $dsn = str_replace('redis://', '', $dsn); // remove "redis://"
+        $dsn = preg_replace('#rediss?://#', '', $dsn); // remove "redis://" and "rediss://"
         if (false !== $pos = strrpos($dsn, '@')) {
             // parse password
             $password = substr($dsn, 0, $pos);
@@ -195,6 +208,8 @@ class RedisDsn
                 $this->port = (int) $matches[3];
             }
         }
+
+        $this->tls = 0 === strpos($this->dsn, 'rediss://');
     }
 
     /**

--- a/Factory/PredisParametersFactory.php
+++ b/Factory/PredisParametersFactory.php
@@ -37,7 +37,7 @@ class PredisParametersFactory
             $options['scheme'] = 'unix';
             $options['path'] = $dsn->getSocket();
         } else {
-            $options['scheme'] = 'tcp';
+            $options['scheme'] = $dsn->getTls() ? 'tls' : 'tcp';
             $options['host'] = $dsn->getHost();
             $options['port'] = $dsn->getPort();
             if (null !== $dsn->getDatabase()) {

--- a/Tests/DependencyInjection/Configuration/RedisDsnTest.php
+++ b/Tests/DependencyInjection/Configuration/RedisDsnTest.php
@@ -62,6 +62,7 @@ class RedisDsnTest extends TestCase
             array('redis://%redis_host%:%redis_port%', '%redis_host%'),
             array('redis://%redis_host%:%redis_port%/%redis_db%', '%redis_host%'),
             array('redis://%redis_pass%@%redis_host%:%redis_port%/%redis_db%', '%redis_host%'),
+            array('rediss://localhost', 'localhost'),
         );
     }
 
@@ -110,6 +111,26 @@ class RedisDsnTest extends TestCase
         $this->assertSame($socket, $dsn->getSocket());
     }
 
+    public function tlsValues()
+    {
+        return array(
+            array('redis://localhost', false),
+            array('rediss://localhost', true),
+        );
+    }
+
+    /**
+     * @param string $dsn DSN
+     * @param string $tls TLS
+     *
+     * @dataProvider tlsValues
+     */
+    public function testTls($dsn, $tls)
+    {
+        $dsn = new RedisDsn($dsn);
+        $this->assertSame($tls, $dsn->getTls());
+    }
+
     /**
      * @static
      *
@@ -120,6 +141,7 @@ class RedisDsnTest extends TestCase
         return array(
             array('redis://localhost', 6379),
             array('redis://localhost/1', 6379),
+            array('rediss://localhost:6380', 6380),
             array('redis://localhost:63790', 63790),
             array('redis://localhost:63790/10', 63790),
             array('redis://pw@localhost:63790/10', 63790),
@@ -250,6 +272,7 @@ class RedisDsnTest extends TestCase
     {
         return array(
             array('redis://localhost', true),
+            array('rediss://localhost', true),
             array('redis://localhost/1', true),
             array('redis://pw@localhost:63790/10', true),
             array('redis://127.0.0.1', true),

--- a/Tests/Factory/PredisParametersFactoryTest.php
+++ b/Tests/Factory/PredisParametersFactoryTest.php
@@ -61,6 +61,17 @@ class PredisParametersFactoryTest extends TestCase
                     'password' => 'pw',
                     'database' => 10,
                 ),
+            ),
+            array(
+                'rediss://pw@localhost:6380',
+                'Predis\Connection\Parameters',
+                array(),
+                array(
+                    'scheme' => 'tls',
+                    'host' => 'localhost',
+                    'port' => 6380,
+                    'password' => 'pw'
+                )
             )
         );
     }


### PR DESCRIPTION
This should fix issue #444, i.e. connecting to Redis over TLS with a DSN that starts with `rediss://`.