### PR TITLE
Rename lib Redis to Predis\Client. Redis is wrong name when used with…

### DIFF
--- a/Client/Phpredis/Client.php
+++ b/Client/Phpredis/Client.php
@@ -13,7 +13,7 @@
 
 namespace Snc\RedisBundle\Client\Phpredis;
 
-use Redis;
+use Predis\Client as Redis;
 use Snc\RedisBundle\Logger\RedisLogger;
 
 /**


### PR DESCRIPTION
Redis to Predis\Client.