### PR TITLE
Add Support for Phpredis\RedisCluster (#453)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ matrix:
     - php: nightly
     - env: SYMFONY_VERSION="4.4.*" SYMFONY_DEPRECATIONS_HELPER="weak" STABILITY="dev"
 
+dist: xenial
 sudo: false
 
 cache:
@@ -39,15 +40,17 @@ env:
 
 before_install:
   - phpenv config-rm xdebug.ini || true
-  - if [[ $TRAVIS_PHP_VERSION != hhvm ]]; then echo "extension = redis.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi;
+  - if [[ ${TRAVIS_PHP_VERSION} != hhvm ]]; then echo "extension = redis.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi;
   - php -i | grep -i --color=never "Redis Version"
-  - if [[ $TRAVIS_PHP_VERSION != hhvm ]]; then phpenv rehash; fi;
+  - if [[ ${TRAVIS_PHP_VERSION} != hhvm ]]; then phpenv rehash; fi;
   - composer self-update
-  - if ! [ -z "$STABILITY" ]; then composer config minimum-stability ${STABILITY}; fi;
-  - if [ "$SYMFONY_VERSION" != "" ]; then composer require --no-update symfony/symfony:${SYMFONY_VERSION}; fi;
+  - if ! [ -z "${STABILITY}" ]; then composer config minimum-stability ${STABILITY}; fi;
+  - if [ "${SYMFONY_VERSION}" != "" ]; then composer require --no-update symfony/symfony:${SYMFONY_VERSION}; fi;
+  - for PORT in {7000..7008}; do sudo redis-server --port ${PORT} --cluster-enabled yes --cluster-config-file ${PORT}.conf --daemonize yes; echo 127.0.0.1:${PORT}; done
+  - echo yes | redis-cli --cluster create $(seq -f 127.0.0.1:%g 7000 7008) --cluster-replicas 2
 
 install:
-  - composer update --no-interaction --no-progress $COMPOSER_FLAGS
+  - composer update --no-interaction --no-progress ${COMPOSER_FLAGS}
 
 before_script:
   - mkdir Snc && ln -s ../ Snc/RedisBundle

--- a/Client/Phpredis/ClientCluster.php
+++ b/Client/Phpredis/ClientCluster.php
@@ -1,29 +1,16 @@
 <?php
 
-/*
- * This file is part of the SncRedisBundle package.
- *
- * (c) Henrik Westphal <henrik.westphal@gmail.com>
- * (c) Yassine Khial <yassine.khial@blablacar.com>
- * (c) Pierre Boudelle <pierre.boudelle@gmail.com>
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace Snc\RedisBundle\Client\Phpredis;
 
-use Redis;
+use RedisCluster;
 use Snc\RedisBundle\Logger\RedisLogger;
 
 /**
- * PHP Redis client with logger.
+ * PHP RedisCluster client with logger.
  *
- * @author Henrik Westphal <henrik.westphal@gmail.com>
- * @author Yassine Khial <yassine.khial@blablacar.com>
- * @author Pierre Boudelle <pierre.boudelle@gmail.com>
+ * @author Igor Scabini <furester@gmail.com>
  */
-class Client extends Redis
+class ClientCluster extends RedisCluster
 {
     /**
      * @var RedisLogger
@@ -41,10 +28,12 @@ class Client extends Redis
      * @param array       $parameters List of parameters (only `alias` key is handled)
      * @param RedisLogger $logger     A RedisLogger instance
      */
-    public function __construct(array $parameters = array(), RedisLogger $logger = null)
+    public function __construct(array $seeds = array(), array $parameters = array(), RedisLogger $logger = null)
     {
         $this->logger = $logger;
-        $this->alias = isset($parameters['alias']) ? $parameters['alias'] : '';
+        $this->alias = $parameters['alias'] ?? '';
+
+        parent::__construct(null, $seeds);
     }
 
     /**
@@ -112,71 +101,7 @@ class Client extends Redis
     /**
      * {@inheritdoc}
      */
-    public function connect($host, $port = 6379, $timeout = 0.0, $reserved = null, $retry_interval = 0, $read_timeout = 0.0)
-    {
-        return $this->call('connect', func_get_args());
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function isConnected()
-    {
-        return $this->call('isConnected', func_get_args());
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function open($host, $port = 6379, $timeout = 0.0, $reserved = null, $retry_interval = 0, $read_timeout = 0.0)
-    {
-        return $this->call('open', func_get_args());
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function pconnect($host, $port = 6379, $timeout = 0.0, $persistent_id = null, $retry_interval = 0, $read_timeout = 0.0)
-    {
-        return $this->call('pconnect', func_get_args());
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function popen($host, $port = 6379, $timeout = 0.0, $persistent_id = '', $retry_interval = 0, $read_timeout = 0.0)
-    {
-        return $this->call('popen', func_get_args());
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function close()
-    {
-        return $this->call('close', func_get_args());
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function setOption($name, $value)
-    {
-        return $this->call('setOption', func_get_args());
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getOption($name)
-    {
-        return $this->call('getOption', func_get_args());
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function ping()
+    public function ping($key_or_address)
     {
         return $this->call('ping', func_get_args());
     }
@@ -211,7 +136,7 @@ class Client extends Redis
     public function psetex($key, $ttl, $value)
     {
         return $this->call('psetex', func_get_args());
-    }
+    }    
 
     /**
      * {@inheritdoc}
@@ -248,7 +173,7 @@ class Client extends Redis
     /**
      * {@inheritdoc}
      */
-    public function multi($mode = Redis::MULTI)
+    public function multi($mode = RedisCluster::MULTI)
     {
         return $this->call('multi', func_get_args());
     }
@@ -312,9 +237,9 @@ class Client extends Redis
     /**
      * {@inheritdoc}
      */
-    public function pubsub($cmd, ...$args)
+    public function pubsub($key_or_address, $arg = null, ...$other_args)
     {
-        return $this->call('pubsub', array_merge([$cmd], $args));
+        return $this->call('pubsub', array_merge([$key_or_address, $arg], $other_args));
     }
 
     /**
@@ -528,7 +453,7 @@ class Client extends Redis
     /**
      * {@inheritdoc}
      */
-    public function lRem($key, $value, $count)
+    public function lRem($key, $value)
     {
         return $this->call('lRem', func_get_args());
     }
@@ -688,7 +613,7 @@ class Client extends Redis
     /**
      * {@inheritdoc}
      */
-    public function sScan($key, &$iterator, $pattern = null, $count = 0)
+    public function sScan($key, &$iterator, $pattern = null, $count = null)
     {
         return $this->call('sScan', array($key, &$iterator, $pattern, $count));
     }
@@ -704,25 +629,9 @@ class Client extends Redis
     /**
      * {@inheritdoc}
      */
-    public function randomKey()
+    public function randomKey($key_or_address)
     {
         return $this->call('randomKey', func_get_args());
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function select($dbindex)
-    {
-        return $this->call('select', func_get_args());
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function move($key, $dbindex)
-    {
-        return $this->call('move', func_get_args());
     }
 
     /**
@@ -808,7 +717,7 @@ class Client extends Redis
     /**
      * {@inheritdoc}
      */
-    public function dbSize()
+    public function dbSize($key_or_address)
     {
         return $this->call('dbSize', func_get_args());
     }
@@ -816,15 +725,7 @@ class Client extends Redis
     /**
      * {@inheritdoc}
      */
-    public function auth($password)
-    {
-        return $this->call('auth', func_get_args());
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function bgrewriteaof()
+    public function bgrewriteaof($key_or_address)
     {
         return $this->call('bgrewriteaof', func_get_args());
     }
@@ -848,7 +749,7 @@ class Client extends Redis
     /**
      * {@inheritdoc}
      */
-    public function save()
+    public function save($key_or_address)
     {
         return $this->call('save', func_get_args());
     }
@@ -856,7 +757,7 @@ class Client extends Redis
     /**
      * {@inheritdoc}
      */
-    public function bgsave()
+    public function bgsave($key_or_address)
     {
         return $this->call('bgsave', func_get_args());
     }
@@ -864,7 +765,7 @@ class Client extends Redis
     /**
      * {@inheritdoc}
      */
-    public function lastSave()
+    public function lastSave($key_or_address)
     {
         return $this->call('lastSave', func_get_args());
     }
@@ -968,7 +869,7 @@ class Client extends Redis
     /**
      * {@inheritdoc}
      */
-    public function flushDB($async = NULL)
+    public function flushDB($key_or_address, $async = null)
     {
         return $this->call('flushDB', func_get_args());
     }
@@ -976,9 +877,9 @@ class Client extends Redis
     /**
      * {@inheritdoc}
      */
-    public function flushAll($async = NULL)
+    public function flushAll(...$args)
     {
-        return $this->call('flushAll', func_get_args());
+        return $this->call('flushAll', $args);
     }
 
     /**
@@ -992,7 +893,7 @@ class Client extends Redis
     /**
      * {@inheritdoc}
      */
-    public function info($option = null)
+    public function info($key_or_address, $option = null)
     {
         return $this->call('info', func_get_args());
     }
@@ -1232,23 +1133,7 @@ class Client extends Redis
     /**
      * {@inheritdoc}
      */
-    public function zUnion($Output, $ZSetKeys, array $Weights = null, $aggregateFunction = 'SUM')
-    {
-        return $this->call('zUnion', func_get_args());
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function zInter($Output, $ZSetKeys, array $Weights = null, $aggregateFunction = 'SUM')
-    {
-        return $this->call('zInter', func_get_args());
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function zScan($key, &$iterator, $pattern = null, $count = 0)
+    public function zScan($key, &$iterator, $pattern = null, $count = null)
     {
         return $this->call('zScan', array($key, &$iterator, $pattern, $count));
     }
@@ -1346,7 +1231,7 @@ class Client extends Redis
      */
     public function hMSet($key, $hashKeys)
     {
-        return $this->call('hMSet', func_get_args());
+        return $this->call('hMset', func_get_args());
     }
 
     /**
@@ -1360,7 +1245,7 @@ class Client extends Redis
     /**
      * {@inheritdoc}
      */
-    public function hScan($key, &$iterator, $pattern = null, $count = 0)
+    public function hScan($key, &$iterator, $pattern = null, $count = null)
     {
         return $this->call('hScan', array($key, &$iterator, $pattern, $count));
     }
@@ -1368,7 +1253,7 @@ class Client extends Redis
     /**
      * {@inheritdoc}
      */
-    public function config($cmd, $key, $value = null)
+    public function config($key_or_address, $arg = null, ...$other_args)
     {
         return $this->call('config', func_get_args());
     }
@@ -1400,7 +1285,7 @@ class Client extends Redis
     /**
      * {@inheritdoc}
      */
-    public function script($cmd, ...$args)
+    public function script($key_or_address, $arg = null, ...$other_args)
     {
         return $this->call('script', func_get_args());
     }
@@ -1480,7 +1365,7 @@ class Client extends Redis
     /**
      * {@inheritdoc}
      */
-    public function scan(&$iterator, $pattern = null, $count = 0)
+    public function scan(&$i_iterator, $str_node, $str_pattern = null, $i_count = null)
     {
         return $this->call('scan', array(&$iterator, $pattern, $count));
     }

--- a/Command/RedisFlushallCommand.php
+++ b/Command/RedisFlushallCommand.php
@@ -11,7 +11,6 @@
 
 namespace Snc\RedisBundle\Command;
 
-
 /**
  * Symfony command to execute redis flushall
  *
@@ -19,7 +18,6 @@ namespace Snc\RedisBundle\Command;
  */
 class RedisFlushallCommand extends RedisBaseCommand
 {
-
     /**
      * {@inheritDoc}
      */
@@ -48,6 +46,10 @@ class RedisFlushallCommand extends RedisBaseCommand
      */
     private function flushAll()
     {
+        if ($this->redisClient instanceof \RedisCluster) {
+            throw new \RuntimeException('\RedisCluster support is not yet implemented for this command');
+        }
+
         if (!($this->redisClient instanceof \IteratorAggregate) || // BC for Predis 1.0
             // bug fix https://github.com/nrk/predis/issues/552
             !($this->redisClient->getConnection() instanceof \Traversable)
@@ -62,5 +64,4 @@ class RedisFlushallCommand extends RedisBaseCommand
 
         $this->output->writeln('<info>All redis databases flushed</info>');
     }
-
 }

--- a/Command/RedisFlushdbCommand.php
+++ b/Command/RedisFlushdbCommand.php
@@ -18,7 +18,6 @@ namespace Snc\RedisBundle\Command;
  */
 class RedisFlushdbCommand extends RedisBaseCommand
 {
-
     /**
      * {@inheritDoc}
      */
@@ -47,6 +46,10 @@ class RedisFlushdbCommand extends RedisBaseCommand
      */
     private function flushDbForClient()
     {
+        if ($this->redisClient instanceof \RedisCluster) {
+            throw new \RuntimeException('\RedisCluster support is not yet implemented for this command');
+        }
+
         if (
             !($this->redisClient instanceof \IteratorAggregate) || // BC for Predis 1.0
             // bug fix https://github.com/nrk/predis/issues/552
@@ -62,6 +65,5 @@ class RedisFlushdbCommand extends RedisBaseCommand
 
         $this->output->writeln('<info>redis database flushed</info>');
     }
-
 }
 

--- a/DependencyInjection/Configuration/Configuration.php
+++ b/DependencyInjection/Configuration/Configuration.php
@@ -58,6 +58,8 @@ class Configuration implements ConfigurationInterface
                         ->scalarNode('connection_wrapper')->defaultValue('Snc\RedisBundle\Client\Predis\Connection\ConnectionWrapper')->end()
                         ->scalarNode('phpredis_client')->defaultValue('Redis')->end()
                         ->scalarNode('phpredis_connection_wrapper')->defaultValue('Snc\RedisBundle\Client\Phpredis\Client')->end()
+                        ->scalarNode('phpredis_clusterclient')->defaultValue('RedisCluster')->end()
+                        ->scalarNode('phpredis_clusterclient_connection_wrapper')->defaultValue('Snc\RedisBundle\Client\Phpredis\ClientCluster')->end()
                         ->scalarNode('logger')->defaultValue('Snc\RedisBundle\Logger\RedisLogger')->end()
                         ->scalarNode('data_collector')->defaultValue('Snc\RedisBundle\DataCollector\RedisDataCollector')->end()
                         ->scalarNode('doctrine_cache_phpredis')->defaultValue('Doctrine\Common\Cache\RedisCache')->end()

--- a/Factory/PredisParametersFactory.php
+++ b/Factory/PredisParametersFactory.php
@@ -16,7 +16,7 @@ class PredisParametersFactory
      */
     public static function create($options, $class, $dsn)
     {
-        if (!is_a($class, '\Predis\Connection\ParametersInterface', true)) {
+        if (!is_a($class, ParametersInterface::class, true)) {
             throw new \InvalidArgumentException(sprintf('%s::%s requires $class argument to implement %s', __CLASS__, __METHOD__, ParametersInterface::class));
         }
 

--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -141,6 +141,23 @@ be omitted from the DSNs. Also make sure to use the sentinel port number
 (26379 by default) in the DSNs, and not the default Redis port.
 You can find more information about this on [Configuring Sentinel](https://redis.io/topics/sentinel#configuring-sentinel).
 
+A setup using `RedisCluster` from `phpredis`  could look like this:
+
+``` yaml
+snc_redis:
+    clients:
+        default:
+            type: phpredis
+            alias: default
+            dsn:
+                - redis://localhost:7000
+                - redis://localhost:7001
+                - redis://localhost:7002
+            options:
+                cluster: true
+```
+
+
 ### Sessions ###
 
 Use Redis sessions by adding the following to your config:
@@ -348,7 +365,7 @@ snc_redis:
                 read_write_timeout: 30
                 iterable_multibulk: false
                 throw_errors: true
-                cluster: Snc\RedisBundle\Client\Predis\Connection\PredisCluster
+                cluster: predis
     session:
         client: default
         prefix: foo

--- a/Tests/Client/Phpredis/ClientClusterTest.php
+++ b/Tests/Client/Phpredis/ClientClusterTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Snc\RedisBundle\Tests\Client\Phpredis;
+
+use PHPUnit\Framework\TestCase;
+use Snc\RedisBundle\Client\Phpredis\ClientCluster;
+
+/**
+ * ClientClusterTest
+ */
+class ClientClusterTest extends TestCase
+{
+    protected function setUp()
+    {
+        if (!extension_loaded('redis')) {
+            $this->markTestSkipped('This test needs the PHP Redis extension to work');
+        } elseif (version_compare(phpversion('redis'), '4.0.0') >= 0) {
+            $this->markTestSkipped('This test cannot be executed on Redis extension version ' . phpversion('redis'));
+        } elseif (!@fsockopen('127.0.0.1', 7000)) {
+            $this->markTestSkipped(sprintf('The %s requires a redis instance listening on 127.0.0.1:7000.', __CLASS__));
+        }
+    }
+
+    /**
+     * @covers \Snc\RedisBundle\Client\Phpredis\ClientCluster::getCommandString
+     */
+    public function testGetCommandString()
+    {
+        $method = new \ReflectionMethod(
+            ClientCluster::class, 'getCommandString'
+        );
+
+        $method->setAccessible(true);
+
+        $seeds = array('127.0.0.1:7000', '127.0.0.1:7002');
+        $name = 'foo';
+        $arguments = array(array('chuck', 'norris'));
+
+        $this->assertEquals(
+            'FOO chuck norris', $method->invoke(new ClientCluster($seeds, array('alias' => 'bar')), $name, $arguments)
+        );
+
+        $arguments = array('chuck:norris');
+
+        $this->assertEquals(
+            'FOO chuck:norris', $method->invoke(new ClientCluster($seeds, array('alias' => 'bar')), $name, $arguments)
+        );
+
+        $arguments = array('chuck:norris fab:pot');
+
+        $this->assertEquals(
+            'FOO chuck:norris fab:pot', $method->invoke(new ClientCluster($seeds, array('alias' => 'bar')), $name, $arguments)
+        );
+
+        $arguments = array('foo' => 'bar', 'baz' => null);
+
+        $this->assertEquals(
+            'FOO foo bar baz <null>', $method->invoke(new ClientCluster($seeds, array('alias' => 'bar')), $name, $arguments)
+        );
+    }
+}

--- a/Tests/DependencyInjection/Fixtures/config/yaml/env_phpredis_cluster.yaml
+++ b/Tests/DependencyInjection/Fixtures/config/yaml/env_phpredis_cluster.yaml
@@ -1,0 +1,12 @@
+parameters:
+    env(REDIS_URL_1): redis://localhost:7000
+
+snc_redis:
+    clients:
+        phprediscluster:
+            type: phpredis
+            alias: phprediscluster
+            dsn:
+                - "%env(REDIS_URL_1)%"
+            options:
+                cluster: true

--- a/Tests/DependencyInjection/SncRedisExtensionEnvTest.php
+++ b/Tests/DependencyInjection/SncRedisExtensionEnvTest.php
@@ -118,6 +118,33 @@ class SncRedisExtensionEnvTest extends TestCase
         $this->assertEquals(array('snc_redis.default' => array(array('alias' => 'default'))), $container->findTaggedServiceIds('snc_redis.client'));
     }
 
+    public function testPhpRedisClusterOption()
+    {
+        $container = $this->getConfiguredContainer('env_phpredis_cluster');
+        $clientDefinition = $container->findDefinition('snc_redis.phprediscluster');
+
+        $this->assertSame('RedisCluster', $clientDefinition->getClass());
+        $this->assertSame('RedisCluster', $clientDefinition->getArgument(0));
+        $this->assertContains('REDIS_URL_1', $clientDefinition->getArgument(1));
+        $this->assertSame('phprediscluster', $clientDefinition->getArgument(3));
+
+        $this->assertSame(array(
+                'cluster' => true,
+                'connection_async' => false,
+                'connection_persistent' => false,
+                'connection_timeout' => 5,
+                'read_write_timeout' => null,
+                'iterable_multibulk' => false,
+                'throw_errors' => true,
+                'serialization' => 'default',
+                'profile' => 'default',
+                'prefix' => null,
+                'service' => null,
+            ),
+            $clientDefinition->getArgument(2)
+        );
+    }
+
     private function getConfiguredContainer($file)
     {
         $container = new ContainerBuilder();

--- a/Tests/DependencyInjection/SncRedisExtensionTest.php
+++ b/Tests/DependencyInjection/SncRedisExtensionTest.php
@@ -457,6 +457,22 @@ class SncRedisExtensionTest extends TestCase
         $this->assertSame('pass', $redis->getAuth());
     }
 
+    /**
+     * Test minimal RedisCluster configuration
+     */
+    public function testPhpRedisClusterParameters()
+    {
+        $extension = new SncRedisExtension();
+        $config = $this->parseYaml($this->getPhpRedisClusterYamlMinimalConfig());
+        $extension->load(array($config), $container = $this->getContainer());
+
+        $defaultParameters = $container->getDefinition('snc_redis.default');
+
+        $redis = $container->get('snc_redis.default');
+
+        $this->assertInstanceOf('\RedisCluster', $redis);
+    }
+
     private function parseYaml($yaml)
     {
         $parser = new Parser();
@@ -532,7 +548,7 @@ clients:
             read_write_timeout: 30
             iterable_multibulk: false
             throw_errors: true
-            cluster: Snc\RedisBundle\Client\Predis\Connection\PredisCluster
+            cluster: predis
             parameters:
                 database: 1
                 password: pass
@@ -760,6 +776,19 @@ clients:
 EOF;
     }
 
+    private function getPhpRedisClusterYamlMinimalConfig()
+    {
+        return <<<'EOF'
+clients:
+    default:
+        type: phpredis
+        alias: default
+        dsn: ["redis://localhost:7000/0"]
+        options:
+            cluster: true
+EOF;
+    }
+    
     private function getContainer()
     {
         return new ContainerBuilder(new ParameterBag(array(

--- a/Tests/Factory/PhpredisClientFactoryTest.php
+++ b/Tests/Factory/PhpredisClientFactoryTest.php
@@ -14,9 +14,7 @@ class PhpredisClientFactoryTest extends TestCase
     {
         if (!class_exists(\Redis::class)) {
             $this->markTestSkipped(sprintf('The %s requires phpredis extension.', __CLASS__));
-        }
-
-        if (!@fsockopen('127.0.0.1', 6379)) {
+        } elseif (!@fsockopen('127.0.0.1', 6379)) {
             $this->markTestSkipped(sprintf('The %s requires a redis instance listening on 127.0.0.1:6379.', __CLASS__));
         }
 
@@ -36,6 +34,17 @@ class PhpredisClientFactoryTest extends TestCase
         $this->assertSame(0, $client->getDBNum());
         $this->assertNull($client->getAuth());
         $this->assertNull($client->getPersistentID());
+    }
+
+    public function testCreateMinimalClusterConfig()
+    {
+        $factory = new PhpredisClientFactory();
+
+        $client = $factory->create(\RedisCluster::class, 'redis://localhost:7000/0', array(), 'phprediscluster');
+
+        $this->assertInstanceOf(\RedisCluster::class, $client);
+        $this->assertNull($client->getOption(\Redis::OPT_PREFIX));
+        $this->assertSame(0, $client->getOption(\Redis::OPT_SERIALIZER));
     }
 
     public function testCreateFullConfig()

--- a/Tests/Functional/IntegrationTest.php
+++ b/Tests/Functional/IntegrationTest.php
@@ -15,7 +15,6 @@ namespace Snc\RedisBundle\Tests\Functional;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Tools\SchemaTool;
-use Snc\RedisBundle\Command\RedisFlushallCommand;
 use Snc\RedisBundle\DataCollector\RedisDataCollector;
 use Snc\RedisBundle\Tests\Functional\App\Kernel;
 use Symfony\Bundle\FrameworkBundle\Client;
@@ -24,7 +23,6 @@ use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Profiler\Profile;
 
 /**
  * IntegrationTest


### PR DESCRIPTION
This shoudl fix issue #453 with a couple of constraints:

Added a configuration parameter to switch between RedisCluster implementations (`snc_redis.phpredis_clusterclient.class`) and based on `cluster` option in client configuration switch between `\Redis` and `\RedisCluster`.

`Snc\RedisBundle\Client\Phpredis\ClientInterface` is implemented by both `Snc\RedisBundle\Client\Phpredis\Client` and `Snc\RedisBundle\Client\Phpredis\ClientCluster`, but directed node commands are commented out.

