### PR TITLE
[Fix][Predis] Fixes persistent connections when used many databases on the same instance

### DIFF
--- a/Factory/PredisParametersFactory.php
+++ b/Factory/PredisParametersFactory.php
@@ -23,6 +23,10 @@ class PredisParametersFactory
         $dsnOptions = static::parseDsn(new RedisDsn($dsn));
         $dsnOptions = array_merge($options, $dsnOptions);
 
+        if (isset($dsnOptions['persistent'], $dsnOptions['database']) && true === $dsnOptions['persistent']) {
+            $dsnOptions['persistent'] = (int)$dsnOptions['database'];
+        }
+
         return new $class($dsnOptions);
     }
 


### PR DESCRIPTION
At the moment, the parameter value can only be boolean, so remote socket does not have a unique identifier. This is a potential error for those who use multiple databases on the same redis instance.

[Reference on predis code](https://github.com/nrk/predis/blob/v1.1/src/Connection/StreamConnection.php#L173)

Old PR(for phpredis):
https://github.com/snc/SncRedisBundle/pull/276
https://github.com/snc/SncRedisBundle/pull/308