### PR TITLE
Fix: No need to verify whether hard dependency is not null

### DIFF
--- a/DataCollector/RedisDataCollector.php
+++ b/DataCollector/RedisDataCollector.php
@@ -42,7 +42,7 @@ class RedisDataCollector extends DataCollector
     public function collect(Request $request, Response $response, \Exception $exception = null)
     {
         $this->data = array(
-            'commands' => null !== $this->logger ? $this->logger->getCommands() : array(),
+            'commands' => $this->logger->getCommands(),
         );
     }
 


### PR DESCRIPTION
This PR

* [x] removes what appears to be a condition that should not evaluate to `false`