### PR TITLE
Enhancement: Add note about usage with symfony/web-profiler-bundle

### DIFF
--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -380,6 +380,21 @@ snc_redis:
         ttl: 3600
 ```
 
+## Usage with `symfony/web-profiler-bundle`
+
+If you are using [`symfony/web-profiler-bundle`](https://github.com/symfony/web-profiler-bundle)
+and want to inspect commands sent by a configured Redis client, logging needs to be enabled for that client.
+
+``` yaml
+snc_redis:
+    clients:
+        default:
+            type: predis
+            alias: default
+            dsn: redis://localhost/
+            logging: '%kernel.debug%'
+```
+
 ## Troubleshooting ##
 
 If cache warmup fails for prod because a redis server is not available,


### PR DESCRIPTION
This PR

* [x] adds a note about usage with [`symfony/web-profiler-bundle`](https://github.com/symfony/web-profiler-bundle)

💁‍♂️ I have been scratching my head a bit, wondering why the Redis tab appears in the profiler, but no commands are listed, and from the documentation it's not quite obvious that it needs to be explicitly enabled.