### PR TITLE
Supply name for new TreeBuilder instead of calling root method

### DIFF
--- a/DependencyInjection/Configuration/Configuration.php
+++ b/DependencyInjection/Configuration/Configuration.php
@@ -11,6 +11,7 @@
 
 namespace Snc\RedisBundle\DependencyInjection\Configuration;
 
+use function method_exists;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
@@ -36,8 +37,14 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('snc_redis');
+        $treeBuilder = new TreeBuilder('snc_redis');
+
+        if (method_exists($treeBuilder, 'getRootNode')) {
+            $rootNode = $treeBuilder->getRootNode();
+        } else {
+            // BC layer for symfony/config 4.1 and older
+            $rootNode = $treeBuilder->root('snc_redis');
+        }
 
         $rootNode
             ->children()


### PR DESCRIPTION
Creating a new TreeBuilder without root node information is
deprecated since Symfony 4.2.

See https://github.com/symfony/symfony/blob/master/UPGRADE-4.2.md#config