### PR TITLE
Fix: Explicitly configure Travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,19 +3,17 @@ language: php
 services:
   - redis-server
 
-php:
-  - 7.0
-  - 7.1
-  - 7.2
-
 matrix:
   include:
-    - php: 7.1
-      env: SYMFONY_VERSION="3.4.*"
-    - php: 7.2
-      env: SYMFONY_VERSION="3.4.*"
     - php: 7.0
       env: COMPOSER_FLAGS="--prefer-lowest" SYMFONY_DEPRECATIONS_HELPER="weak"
+    - php: 7.0
+    - php: 7.1
+      env: SYMFONY_VERSION="3.4.*"
+    - php: 7.1
+    - php: 7.2
+      env: SYMFONY_VERSION="3.4.*"
+    - php: 7.2
 
 sudo: false
 


### PR DESCRIPTION
This PR

* [x] explicitly configures the Travis build matrix

💁‍♂️ I think it's nice to have a specific order in the matrix.

### Before

![screen shot 2018-11-17 at 16 11 14](https://user-images.githubusercontent.com/605483/48662530-8bb04300-ea83-11e8-8824-3cc87f9afb07.png)

### After

![screen shot 2018-11-17 at 16 14 47](https://user-images.githubusercontent.com/605483/48662553-ed70ad00-ea83-11e8-9eb4-2c44e91fb51b.png)
