### PR TITLE
Fix: Make script step explicit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,3 +37,6 @@ install:
 
 before_script:
   - mkdir Snc && ln -s ../ Snc/RedisBundle
+
+script:
+  - bin/phpunit


### PR DESCRIPTION
This PR

* [x] makes the `script` step explicit

💁‍♂️ For reference, see https://docs.travis-ci.com/user/languages/php#default-build-script.