### PR TITLE
Update Travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,15 +5,12 @@ services:
 
 matrix:
   include:
-    - php: 7.0
+    - php: 7.2
       env: COMPOSER_FLAGS="--prefer-lowest" SYMFONY_DEPRECATIONS_HELPER="weak"
-    - php: 7.0
-    - php: 7.1
-      env: SYMFONY_VERSION="3.4.*"
-    - php: 7.1
     - php: 7.2
       env: SYMFONY_VERSION="3.4.*"
     - php: 7.2
+    - php: 7.3
 
 sudo: false
 


### PR DESCRIPTION
As PHP 7.0 is EOL and PHP 7.1 unsupported 

http://php.net/supported-versions.php

Hopefully this also fixes the failing `master`.