### PR TITLE
Use semver for PHP version at `composer.json`, added support for PHP 7.3 at Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ matrix:
       env: SYMFONY_VERSION="4.1.*"
     - php: 7.2
       env: SYMFONY_VERSION="4.2.*" SYMFONY_DEPRECATIONS_HELPER="weak" STABILITY="dev"
+    - php: 7.3
     - php: nightly
   allow_failures:
     - php: hhvm
@@ -47,6 +48,7 @@ env:
 before_install:
   - phpenv config-rm xdebug.ini || true
   - if [[ $TRAVIS_PHP_VERSION != hhvm ]]; then echo "extension = redis.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi;
+  - php -i | grep -i --color=never "Redis Version"
   - if [[ $TRAVIS_PHP_VERSION != hhvm ]]; then phpenv rehash; fi;
   - composer self-update
   - if ! [ -z "$STABILITY" ]; then composer config minimum-stability ${STABILITY}; fi;

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "homepage": "https://github.com/snc/SncRedisBundle/contributors"
     }],
     "require": {
-        "php": ">=5.3.3",
+        "php": "^5.3.3 || ^7.0",
         "symfony/framework-bundle": "^2.7 || ^3.0 || ^4.0",
         "symfony/yaml": "^2.7 || ^3.0 || ^4.0"
     },


### PR DESCRIPTION
|Q            |A  |
|---          |---|
|Branch       |2.1|
|Bug fix?     |no |
|New feature? |no |
|BC breaks?   |no |
|Deprecations?|no |
|Tests pass?  |yes|
|Fixed tickets|n/a|
|License      |MIT|
|Doc PR       |n/a|

`PhpredisClientFactoryTest` was moved under `Tests` namespace, and `testCreateFullConfig()` test is marked with "redis4" group in order to be excluded at CI builds with Redis 4 (see #399).