### PR TITLE
Execute flushdb/flushall in all nodes of cluster

### DIFF
--- a/Command/RedisFlushallCommand.php
+++ b/Command/RedisFlushallCommand.php
@@ -48,7 +48,9 @@ class RedisFlushallCommand extends RedisBaseCommand
      */
     private function flushAll()
     {
-        $this->redisClient->flushall();
+        foreach ($this->redisClient as $nodeClient) {
+            $nodeClient->flushall();
+        }
 
         $this->output->writeln('<info>All redis databases flushed</info>');
     }

--- a/Command/RedisFlushallCommand.php
+++ b/Command/RedisFlushallCommand.php
@@ -48,8 +48,13 @@ class RedisFlushallCommand extends RedisBaseCommand
      */
     private function flushAll()
     {
-        foreach ($this->redisClient as $nodeClient) {
-            $nodeClient->flushall();
+        if (!($this->redisClient instanceof \IteratorAggregate)) { // BC for Predis 1.0
+            $this->redisClient->flushall();
+        } else {
+            // flushall in all nodes of cluster
+            foreach ($this->redisClient as $nodeClient) {
+                $nodeClient->flushall();
+            }
         }
 
         $this->output->writeln('<info>All redis databases flushed</info>');

--- a/Command/RedisFlushdbCommand.php
+++ b/Command/RedisFlushdbCommand.php
@@ -47,7 +47,9 @@ class RedisFlushdbCommand extends RedisBaseCommand
      */
     private function flushDbForClient()
     {
-        $this->redisClient->flushdb();
+        foreach ($this->redisClient as $nodeClient) {
+            $nodeClient->flushdb();
+        }
 
         $this->output->writeln('<info>redis database flushed</info>');
     }

--- a/Command/RedisFlushdbCommand.php
+++ b/Command/RedisFlushdbCommand.php
@@ -47,8 +47,13 @@ class RedisFlushdbCommand extends RedisBaseCommand
      */
     private function flushDbForClient()
     {
-        foreach ($this->redisClient as $nodeClient) {
-            $nodeClient->flushdb();
+        if (!($this->redisClient instanceof \IteratorAggregate)) { // BC for Predis 1.0
+            $this->redisClient->flushdb();
+        } else {
+            // flushall in all nodes of cluster
+            foreach ($this->redisClient as $nodeClient) {
+                $nodeClient->flushdb();
+            }
         }
 
         $this->output->writeln('<info>redis database flushed</info>');

--- a/Tests/Command/RedisFlushAllCommandTest.php
+++ b/Tests/Command/RedisFlushAllCommandTest.php
@@ -30,14 +30,24 @@ class RedisFlushallCommandTest extends CommandTestCase
 
     public function testWithDefaultClientAndNoInteraction()
     {
+        $node1 = $this->getMockBuilder('\Predis\\Client')->getMock();
+        $node1->expects($this->once())
+            ->method('__call')
+            ->with($this->equalTo('flushall'))
+            ->will($this->returnValue(true));
+        $node2 = $this->getMockBuilder('\Predis\\Client')->getMock();
+        $node2->expects($this->once())
+            ->method('__call')
+            ->with($this->equalTo('flushall'))
+            ->will($this->returnValue(true));
+
         $this->container->expects($this->once())
             ->method('get')
             ->with($this->equalTo('snc_redis.default'));
 
         $this->predisClient->expects($this->once())
-            ->method('__call')
-            ->with($this->equalTo('flushall'))
-            ->will($this->returnValue(true));
+            ->method('getIterator')
+            ->will($this->returnValue(new \ArrayIterator([$node1, $node2])));
 
         $command = $this->application->find('redis:flushall');
         $commandTester = new CommandTester($command);
@@ -48,14 +58,24 @@ class RedisFlushallCommandTest extends CommandTestCase
 
     public function testClientOption()
     {
+        $node1 = $this->getMockBuilder('\Predis\\Client')->getMock();
+        $node1->expects($this->once())
+            ->method('__call')
+            ->with($this->equalTo('flushall'))
+            ->will($this->returnValue(true));
+        $node2 = $this->getMockBuilder('\Predis\\Client')->getMock();
+        $node2->expects($this->once())
+            ->method('__call')
+            ->with($this->equalTo('flushall'))
+            ->will($this->returnValue(true));
+
         $this->container->expects($this->once())
             ->method('get')
             ->with($this->equalTo('snc_redis.special'));
 
         $this->predisClient->expects($this->once())
-            ->method('__call')
-            ->with($this->equalTo('flushall'))
-            ->will($this->returnValue(true));
+            ->method('getIterator')
+            ->will($this->returnValue(new \ArrayIterator([$node1, $node2])));
 
         $command = $this->application->find('redis:flushall');
         $commandTester = new CommandTester($command);
@@ -72,7 +92,7 @@ class RedisFlushallCommandTest extends CommandTestCase
             ->will($this->throwException(new \Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException('')));
 
         $this->predisClient->expects($this->never())
-            ->method('__call');
+            ->method('getIterator');
 
         $command = $this->application->find('redis:flushall');
         $commandTester = new CommandTester($command);

--- a/Tests/Command/RedisFlushAllCommandTest.php
+++ b/Tests/Command/RedisFlushAllCommandTest.php
@@ -30,24 +30,31 @@ class RedisFlushallCommandTest extends CommandTestCase
 
     public function testWithDefaultClientAndNoInteraction()
     {
-        $node1 = $this->getMockBuilder('\Predis\\Client')->getMock();
-        $node1->expects($this->once())
-            ->method('__call')
-            ->with($this->equalTo('flushall'))
-            ->will($this->returnValue(true));
-        $node2 = $this->getMockBuilder('\Predis\\Client')->getMock();
-        $node2->expects($this->once())
-            ->method('__call')
-            ->with($this->equalTo('flushall'))
-            ->will($this->returnValue(true));
-
         $this->container->expects($this->once())
             ->method('get')
             ->with($this->equalTo('snc_redis.default'));
 
-        $this->predisClient->expects($this->once())
-            ->method('getIterator')
-            ->will($this->returnValue(new \ArrayIterator([$node1, $node2])));
+        if (!($this->predisClient instanceof \IteratorAggregate)) { // BC for Predis 1.0
+            $this->predisClient->expects($this->once())
+                ->method('__call')
+                ->with($this->equalTo('flushall'))
+                ->will($this->returnValue(true));
+        } else {
+            $node1 = $this->getMockBuilder('\Predis\\Client')->getMock();
+            $node1->expects($this->once())
+                ->method('__call')
+                ->with($this->equalTo('flushall'))
+                ->will($this->returnValue(true));
+            $node2 = $this->getMockBuilder('\Predis\\Client')->getMock();
+            $node2->expects($this->once())
+                ->method('__call')
+                ->with($this->equalTo('flushall'))
+                ->will($this->returnValue(true));
+
+            $this->predisClient->expects($this->once())
+                ->method('getIterator')
+                ->will($this->returnValue(new \ArrayIterator([$node1, $node2])));
+        }
 
         $command = $this->application->find('redis:flushall');
         $commandTester = new CommandTester($command);
@@ -58,24 +65,31 @@ class RedisFlushallCommandTest extends CommandTestCase
 
     public function testClientOption()
     {
-        $node1 = $this->getMockBuilder('\Predis\\Client')->getMock();
-        $node1->expects($this->once())
-            ->method('__call')
-            ->with($this->equalTo('flushall'))
-            ->will($this->returnValue(true));
-        $node2 = $this->getMockBuilder('\Predis\\Client')->getMock();
-        $node2->expects($this->once())
-            ->method('__call')
-            ->with($this->equalTo('flushall'))
-            ->will($this->returnValue(true));
-
         $this->container->expects($this->once())
             ->method('get')
             ->with($this->equalTo('snc_redis.special'));
 
-        $this->predisClient->expects($this->once())
-            ->method('getIterator')
-            ->will($this->returnValue(new \ArrayIterator([$node1, $node2])));
+        if (!($this->predisClient instanceof \IteratorAggregate)) { // BC for Predis 1.0
+            $this->predisClient->expects($this->once())
+                ->method('__call')
+                ->with($this->equalTo('flushall'))
+                ->will($this->returnValue(true));
+        } else {
+            $node1 = $this->getMockBuilder('\Predis\\Client')->getMock();
+            $node1->expects($this->once())
+                ->method('__call')
+                ->with($this->equalTo('flushall'))
+                ->will($this->returnValue(true));
+            $node2 = $this->getMockBuilder('\Predis\\Client')->getMock();
+            $node2->expects($this->once())
+                ->method('__call')
+                ->with($this->equalTo('flushall'))
+                ->will($this->returnValue(true));
+
+            $this->predisClient->expects($this->once())
+                ->method('getIterator')
+                ->will($this->returnValue(new \ArrayIterator([$node1, $node2])));
+        }
 
         $command = $this->application->find('redis:flushall');
         $commandTester = new CommandTester($command);
@@ -91,8 +105,13 @@ class RedisFlushallCommandTest extends CommandTestCase
             ->with($this->equalTo('snc_redis.notExisting'))
             ->will($this->throwException(new \Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException('')));
 
-        $this->predisClient->expects($this->never())
-            ->method('getIterator');
+        if (!($this->predisClient instanceof \IteratorAggregate)) { // BC for Predis 1.0
+            $this->predisClient->expects($this->never())
+                ->method('__call');
+        } else {
+            $this->predisClient->expects($this->never())
+                ->method('getIterator');
+        }
 
         $command = $this->application->find('redis:flushall');
         $commandTester = new CommandTester($command);

--- a/Tests/Command/RedisFlushAllCommandTest.php
+++ b/Tests/Command/RedisFlushAllCommandTest.php
@@ -40,12 +40,12 @@ class RedisFlushallCommandTest extends CommandTestCase
                 ->with($this->equalTo('flushall'))
                 ->will($this->returnValue(true));
         } else {
-            $node1 = $this->getMockBuilder('\Predis\\Client')->getMock();
+            $node1 = $this->getMockBuilder('\Predis\Client')->getMock();
             $node1->expects($this->once())
                 ->method('__call')
                 ->with($this->equalTo('flushall'))
                 ->will($this->returnValue(true));
-            $node2 = $this->getMockBuilder('\Predis\\Client')->getMock();
+            $node2 = $this->getMockBuilder('\Predis\Client')->getMock();
             $node2->expects($this->once())
                 ->method('__call')
                 ->with($this->equalTo('flushall'))
@@ -75,12 +75,12 @@ class RedisFlushallCommandTest extends CommandTestCase
                 ->with($this->equalTo('flushall'))
                 ->will($this->returnValue(true));
         } else {
-            $node1 = $this->getMockBuilder('\Predis\\Client')->getMock();
+            $node1 = $this->getMockBuilder('\Predis\Client')->getMock();
             $node1->expects($this->once())
                 ->method('__call')
                 ->with($this->equalTo('flushall'))
                 ->will($this->returnValue(true));
-            $node2 = $this->getMockBuilder('\Predis\\Client')->getMock();
+            $node2 = $this->getMockBuilder('\Predis\Client')->getMock();
             $node2->expects($this->once())
                 ->method('__call')
                 ->with($this->equalTo('flushall'))

--- a/Tests/Command/RedisFlushdbCommandTest.php
+++ b/Tests/Command/RedisFlushdbCommandTest.php
@@ -30,14 +30,24 @@ class RedisFlushdbCommandTest extends CommandTestCase
 
     public function testDefaultClientAndNoInteraction()
     {
+        $node1 = $this->getMockBuilder('\Predis\\Client')->getMock();
+        $node1->expects($this->once())
+            ->method('__call')
+            ->with($this->equalTo('flushdb'))
+            ->will($this->returnValue(true));
+        $node2 = $this->getMockBuilder('\Predis\\Client')->getMock();
+        $node2->expects($this->once())
+            ->method('__call')
+            ->with($this->equalTo('flushdb'))
+            ->will($this->returnValue(true));
+
         $this->container->expects($this->once())
             ->method('get')
             ->with($this->equalTo('snc_redis.default'));
 
         $this->predisClient->expects($this->once())
-            ->method('__call')
-            ->with($this->equalTo('flushdb'))
-            ->will($this->returnValue(true));
+            ->method('getIterator')
+            ->will($this->returnValue(new \ArrayIterator([$node1, $node2])));
 
         $command = $this->application->find('redis:flushdb');
         $commandTester = new CommandTester($command);
@@ -48,14 +58,24 @@ class RedisFlushdbCommandTest extends CommandTestCase
 
     public function testClientOption()
     {
+        $node1 = $this->getMockBuilder('\Predis\\Client')->getMock();
+        $node1->expects($this->once())
+            ->method('__call')
+            ->with($this->equalTo('flushdb'))
+            ->will($this->returnValue(true));
+        $node2 = $this->getMockBuilder('\Predis\\Client')->getMock();
+        $node2->expects($this->once())
+            ->method('__call')
+            ->with($this->equalTo('flushdb'))
+            ->will($this->returnValue(true));
+
         $this->container->expects($this->once())
             ->method('get')
             ->with($this->equalTo('snc_redis.special'));
 
         $this->predisClient->expects($this->once())
-            ->method('__call')
-            ->with($this->equalTo('flushdb'))
-            ->will($this->returnValue(true));
+            ->method('getIterator')
+            ->will($this->returnValue(new \ArrayIterator([$node1, $node2])));
 
         $command = $this->application->find('redis:flushdb');
         $commandTester = new CommandTester($command);
@@ -72,7 +92,7 @@ class RedisFlushdbCommandTest extends CommandTestCase
             ->will($this->throwException(new \Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException('')));
 
         $this->predisClient->expects($this->never())
-            ->method('__call');
+            ->method('getIterator');
 
         $command = $this->application->find('redis:flushdb');
         $commandTester = new CommandTester($command);

--- a/Tests/Command/RedisFlushdbCommandTest.php
+++ b/Tests/Command/RedisFlushdbCommandTest.php
@@ -30,24 +30,31 @@ class RedisFlushdbCommandTest extends CommandTestCase
 
     public function testDefaultClientAndNoInteraction()
     {
-        $node1 = $this->getMockBuilder('\Predis\\Client')->getMock();
-        $node1->expects($this->once())
-            ->method('__call')
-            ->with($this->equalTo('flushdb'))
-            ->will($this->returnValue(true));
-        $node2 = $this->getMockBuilder('\Predis\\Client')->getMock();
-        $node2->expects($this->once())
-            ->method('__call')
-            ->with($this->equalTo('flushdb'))
-            ->will($this->returnValue(true));
-
         $this->container->expects($this->once())
             ->method('get')
             ->with($this->equalTo('snc_redis.default'));
 
-        $this->predisClient->expects($this->once())
-            ->method('getIterator')
-            ->will($this->returnValue(new \ArrayIterator([$node1, $node2])));
+        if (!($this->predisClient instanceof \IteratorAggregate)) { // BC for Predis 1.0
+            $this->predisClient->expects($this->once())
+                ->method('__call')
+                ->with($this->equalTo('flushdb'))
+                ->will($this->returnValue(true));
+        } else {
+            $node1 = $this->getMockBuilder('\Predis\\Client')->getMock();
+            $node1->expects($this->once())
+                ->method('__call')
+                ->with($this->equalTo('flushdb'))
+                ->will($this->returnValue(true));
+            $node2 = $this->getMockBuilder('\Predis\\Client')->getMock();
+            $node2->expects($this->once())
+                ->method('__call')
+                ->with($this->equalTo('flushdb'))
+                ->will($this->returnValue(true));
+
+            $this->predisClient->expects($this->once())
+                ->method('getIterator')
+                ->will($this->returnValue(new \ArrayIterator([$node1, $node2])));
+        }
 
         $command = $this->application->find('redis:flushdb');
         $commandTester = new CommandTester($command);
@@ -58,24 +65,31 @@ class RedisFlushdbCommandTest extends CommandTestCase
 
     public function testClientOption()
     {
-        $node1 = $this->getMockBuilder('\Predis\\Client')->getMock();
-        $node1->expects($this->once())
-            ->method('__call')
-            ->with($this->equalTo('flushdb'))
-            ->will($this->returnValue(true));
-        $node2 = $this->getMockBuilder('\Predis\\Client')->getMock();
-        $node2->expects($this->once())
-            ->method('__call')
-            ->with($this->equalTo('flushdb'))
-            ->will($this->returnValue(true));
-
         $this->container->expects($this->once())
             ->method('get')
             ->with($this->equalTo('snc_redis.special'));
 
-        $this->predisClient->expects($this->once())
-            ->method('getIterator')
-            ->will($this->returnValue(new \ArrayIterator([$node1, $node2])));
+        if (!($this->predisClient instanceof \IteratorAggregate)) { // BC for Predis 1.0
+            $this->predisClient->expects($this->once())
+                ->method('__call')
+                ->with($this->equalTo('flushdb'))
+                ->will($this->returnValue(true));
+        } else {
+            $node1 = $this->getMockBuilder('\Predis\\Client')->getMock();
+            $node1->expects($this->once())
+                ->method('__call')
+                ->with($this->equalTo('flushdb'))
+                ->will($this->returnValue(true));
+            $node2 = $this->getMockBuilder('\Predis\\Client')->getMock();
+            $node2->expects($this->once())
+                ->method('__call')
+                ->with($this->equalTo('flushdb'))
+                ->will($this->returnValue(true));
+
+            $this->predisClient->expects($this->once())
+                ->method('getIterator')
+                ->will($this->returnValue(new \ArrayIterator([$node1, $node2])));
+        }
 
         $command = $this->application->find('redis:flushdb');
         $commandTester = new CommandTester($command);
@@ -91,8 +105,13 @@ class RedisFlushdbCommandTest extends CommandTestCase
             ->with($this->equalTo('snc_redis.notExisting'))
             ->will($this->throwException(new \Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException('')));
 
-        $this->predisClient->expects($this->never())
-            ->method('getIterator');
+        if (!($this->predisClient instanceof \IteratorAggregate)) { // BC for Predis 1.0
+            $this->predisClient->expects($this->never())
+                ->method('__call');
+        } else {
+            $this->predisClient->expects($this->never())
+                ->method('getIterator');
+        }
 
         $command = $this->application->find('redis:flushdb');
         $commandTester = new CommandTester($command);


### PR DESCRIPTION
This is a bug fix.
If application is configured to use a cluster, then some commands cannot be executed.

```
# ./bin/console redis:flushdb
In PredisCluster.php line 134:

  [Predis\NotSupportedException]
  Cannot use 'FLUSHDB' over clusters of connections.

Exception trace:
 () at /application/vendor/predis/predis/src/Connection/Aggregate/PredisCluster.php:134
 Predis\Connection\Aggregate\PredisCluster->getConnection() at /application/vendor/predis/predis/src/Connection/Aggregate/PredisCluster.php:215
 Predis\Connection\Aggregate\PredisCluster->executeCommand() at /application/vendor/predis/predis/src/Client.php:331
 Predis\Client->executeCommand() at /application/vendor/predis/predis/src/Client.php:314
 Predis\Client->__call() at /application/vendor/snc/redis-bundle/Command/RedisFlushdbCommand.php:50
 Snc\RedisBundle\Command\RedisFlushdbCommand->flushDbForClient() at /application/vendor/snc/redis-bundle/Command/RedisFlushdbCommand.php:39
 Snc\RedisBundle\Command\RedisFlushdbCommand->executeRedisCommand() at /application/vendor/snc/redis-bundle/Command/RedisBaseCommand.php:73
 Snc\RedisBundle\Command\RedisBaseCommand->execute() at /application/vendor/symfony/symfony/src/Symfony/Component/Console/Command/Command.php:255
 Symfony\Component\Console\Command\Command->run() at /application/vendor/symfony/symfony/src/Symfony/Component/Console/Application.php:978
 Symfony\Component\Console\Application->doRunCommand() at /application/vendor/symfony/symfony/src/Symfony/Bundle/FrameworkBundle/Console/Application.php:86
 Symfony\Bundle\FrameworkBundle\Console\Application->doRunCommand() at /application/vendor/symfony/symfony/src/Symfony/Component/Console/Application.php:255
 Symfony\Component\Console\Application->doRun() at /application/vendor/symfony/symfony/src/Symfony/Bundle/FrameworkBundle/Console/Application.php:74
 Symfony\Bundle\FrameworkBundle\Console\Application->doRun() at /application/vendor/symfony/symfony/src/Symfony/Component/Console/Application.php:148
 Symfony\Component\Console\Application->run() at /application/bin/console:50
```

```
# ./bin/console redis:flushall
In PredisCluster.php line 134:

  [Predis\NotSupportedException]
  Cannot use 'FLUSHALL' over clusters of connections.

Exception trace:
 () at /application/vendor/predis/predis/src/Connection/Aggregate/PredisCluster.php:134
 Predis\Connection\Aggregate\PredisCluster->getConnection() at /application/vendor/predis/predis/src/Connection/Aggregate/PredisCluster.php:215
 Predis\Connection\Aggregate\PredisCluster->executeCommand() at /application/vendor/predis/predis/src/Client.php:331
 Predis\Client->executeCommand() at /application/vendor/predis/predis/src/Client.php:314
 Predis\Client->__call() at /application/vendor/snc/redis-bundle/Command/RedisFlushallCommand.php:51
 Snc\RedisBundle\Command\RedisFlushallCommand->flushAll() at /application/vendor/snc/redis-bundle/Command/RedisFlushallCommand.php:40
 Snc\RedisBundle\Command\RedisFlushallCommand->executeRedisCommand() at /application/vendor/snc/redis-bundle/Command/RedisBaseCommand.php:73
 Snc\RedisBundle\Command\RedisBaseCommand->execute() at /application/vendor/symfony/symfony/src/Symfony/Component/Console/Command/Command.php:255
 Symfony\Component\Console\Command\Command->run() at /application/vendor/symfony/symfony/src/Symfony/Component/Console/Application.php:978
 Symfony\Component\Console\Application->doRunCommand() at /application/vendor/symfony/symfony/src/Symfony/Bundle/FrameworkBundle/Console/Application.php:86
 Symfony\Bundle\FrameworkBundle\Console\Application->doRunCommand() at /application/vendor/symfony/symfony/src/Symfony/Component/Console/Application.php:255
 Symfony\Component\Console\Application->doRun() at /application/vendor/symfony/symfony/src/Symfony/Bundle/FrameworkBundle/Console/Application.php:74
 Symfony\Bundle\FrameworkBundle\Console\Application->doRun() at /application/vendor/symfony/symfony/src/Symfony/Component/Console/Application.php:148
 Symfony\Component\Console\Application->run() at /application/bin/console:50
```

See this comment: https://github.com/nrk/predis/issues/338#issuecomment-222905420