### PR TITLE
Fix C&P error in Phpredis Client Proxy Class

### DIFF
--- a/Client/Phpredis/Client.php
+++ b/Client/Phpredis/Client.php
@@ -1482,7 +1482,7 @@ class Client extends Redis
      */
     public function scan(&$iterator, $pattern = null, $count = 0)
     {
-        return $this->call('scan', array($key, &$iterator, $pattern, $count));
+        return $this->call('scan', array(&$iterator, $pattern, $count));
     }
 
     /**


### PR DESCRIPTION
$key is not provided for scan() - seems like due to some C&P action the method body of some of the other scan methods was used.