### PR TITLE
Fixed adding service locator into container & commands

### DIFF
--- a/Command/RedisBaseCommand.php
+++ b/Command/RedisBaseCommand.php
@@ -17,6 +17,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
+use Symfony\Component\DependencyInjection\ServiceLocator;
 
 /**
  * Base command for redis interaction through the command line
@@ -25,30 +26,28 @@ use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
  */
 abstract class RedisBaseCommand extends Command
 {
-    /** @var \Psr\Container\ContainerInterface */
+    /** @var ServiceLocator */
     protected $clientLocator;
 
-    /**
-     * @param \Psr\Container\ContainerInterface $clientLocator
-     *
-     */
-    public function setClientLocator(\Psr\Container\ContainerInterface $clientLocator)
+    public function __construct(ServiceLocator $clientLocator)
     {
         $this->clientLocator = $clientLocator;
+
+        parent::__construct();
     }
 
     /**
-     * @var \Symfony\Component\Console\Input\InputInterface
+     * @var InputInterface
      */
     protected $input;
 
     /**
-     * @var \Symfony\Component\Console\Output\OutputInterface
+     * @var OutputInterface
      */
     protected $output;
 
     /**
-     * @var mixed (Either \Predis\Client or \Snc\RedisBundle\Client\Phpredis\Client)
+     * @var \Predis\Client|\Snc\RedisBundle\Client\Phpredis\Client
      */
     protected $redisClient;
 

--- a/Command/RedisFlushallCommand.php
+++ b/Command/RedisFlushallCommand.php
@@ -11,7 +11,6 @@
 
 namespace Snc\RedisBundle\Command;
 
-
 /**
  * Symfony command to execute redis flushall
  *
@@ -19,6 +18,7 @@ namespace Snc\RedisBundle\Command;
  */
 class RedisFlushallCommand extends RedisBaseCommand
 {
+    protected static $defaultName = 'redis:flushall';
 
     /**
      * {@inheritDoc}
@@ -27,7 +27,7 @@ class RedisFlushallCommand extends RedisBaseCommand
     {
         parent::configure();
 
-        $this->setName('redis:flushall')
+        $this->setName(self::$defaultName)
             ->setDescription('Flushes the redis database using the redis flushall command');
     }
 
@@ -62,5 +62,4 @@ class RedisFlushallCommand extends RedisBaseCommand
 
         $this->output->writeln('<info>All redis databases flushed</info>');
     }
-
 }

--- a/Command/RedisFlushdbCommand.php
+++ b/Command/RedisFlushdbCommand.php
@@ -18,6 +18,7 @@ namespace Snc\RedisBundle\Command;
  */
 class RedisFlushdbCommand extends RedisBaseCommand
 {
+    protected static $defaultName = 'redis:flushdb';
 
     /**
      * {@inheritDoc}
@@ -26,7 +27,7 @@ class RedisFlushdbCommand extends RedisBaseCommand
     {
         parent::configure();
 
-        $this->setName('redis:flushdb')
+        $this->setName(self::$defaultName)
             ->setDescription('Flushes the redis database using the redis flushdb command');
     }
 
@@ -62,6 +63,4 @@ class RedisFlushdbCommand extends RedisBaseCommand
 
         $this->output->writeln('<info>redis database flushed</info>');
     }
-
 }
-

--- a/DependencyInjection/Compiler/ClientLocatorPass.php
+++ b/DependencyInjection/Compiler/ClientLocatorPass.php
@@ -11,19 +11,11 @@
 
 namespace Snc\RedisBundle\DependencyInjection\Compiler;
 
-use Psr\Container\ContainerInterface;
-use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\Compiler\ServiceLocatorTagPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
-use Symfony\Component\DependencyInjection\ServiceLocator;
 
-/**
- * Class ClientLocatorPass
- *
- * @package Snc\RedisBundle\DependencyInjection\Compiler
- */
 class ClientLocatorPass implements CompilerPassInterface
 {
     /**
@@ -31,86 +23,18 @@ class ClientLocatorPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
-        $this->checkForExistingLocatorService($container);
-
-        $clientDefinitions = $this->getRedisClientDefinitions($container);
-
-        $clients = $this->generateServiceClosures($clientDefinitions);
-
-        $clientLocatorDefinition = $this->createClientLocatorDefinition($container, $clients);
-
-        $this->passClientLocatorToSncRedisCommands($container, $clientLocatorDefinition);
-    }
-
-    /**
-     * @param \Psr\Container\ContainerInterface $container
-     */
-    private function checkForExistingLocatorService(ContainerInterface $container)
-    {
-        if ($container->has('snc_redis.client_locator')) {
-            throw new \RuntimeException('service id snc_redis.client_locator already assigned');
-        }
-    }
-
-
-    /**
-     * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
-     *
-     * @return array
-     */
-    private function getRedisClientDefinitions(ContainerBuilder $container): array
-    {
-        $clientDefinitions = $container->findTaggedServiceIds('snc_redis.client');
-        if (!$clientDefinitions) {
-            throw new \RuntimeException('no redis clients found (tag name: snc_redis.client)');
-        }
-
-        return $clientDefinitions;
-    }
-
-
-    /**
-     * @param array $clientDefinitions
-     *
-     * @return array
-     */
-    private function generateServiceClosures(array $clientDefinitions): array
-    {
         $clients = [];
-        foreach (array_keys($clientDefinitions) as $key) {
-            $clients[$key] = new ServiceClosureArgument(new Reference($key));
+        foreach ($container->findTaggedServiceIds('snc_redis.client') as $id => $tagAttributes) {
+            $clients[$id] = new Reference($id);
         }
 
-        return $clients;
-    }
+        if (!$clients) {
+            throw new \RuntimeException('No redis clients found (tag name: snc_redis.client)');
+        }
 
-
-    /**
-     * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
-     * @param array                                                   $clients
-     *
-     * @return \Symfony\Component\DependencyInjection\Definition
-     */
-    private function createClientLocatorDefinition(ContainerBuilder $container, array $clients): Definition
-    {
-        $clientLocatorDefinition = new Definition(ServiceLocator::class, [$clients]);
-        $clientLocatorDefinition->setPrivate(true);
-
-        $container->addDefinitions([$clientLocatorDefinition]);
-
-        return $clientLocatorDefinition;
-    }
-
-    /**
-     * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
-     * @param \Symfony\Component\DependencyInjection\Definition       $clientLocatorDefinition
-     */
-    private function passClientLocatorToSncRedisCommands(ContainerBuilder $container, Definition $clientLocatorDefinition)
-    {
-        $commandDefinitions = $container->findTaggedServiceIds('snc_redis.command');
-        foreach (array_keys($commandDefinitions) as $key) {
-            $commandDefinition = $container->getDefinition($key);
-            $commandDefinition->addMethodCall('setClientLocator', [$clientLocatorDefinition]);
+        foreach ($container->findTaggedServiceIds('snc_redis.command') as $id => $tagAttributes) {
+            $command = $container->findDefinition($id);
+            $command->setArgument(0, ServiceLocatorTagPass::register($container, $clients));
         }
     }
 }

--- a/Tests/DependencyInjection/SncRedisExtensionTest.php
+++ b/Tests/DependencyInjection/SncRedisExtensionTest.php
@@ -407,6 +407,10 @@ class SncRedisExtensionTest extends TestCase
      */
     public function testPhpRedisParameters()
     {
+        if (!class_exists('\\Redis', false)) {
+            $this->markTestSkipped('This test needs the PHP Redis extension to work');
+        }
+
         $extension = new SncRedisExtension();
         $config = $this->parseYaml($this->getPhpRedisYamlConfigWithParameters());
         $extension->load(array($config), $container = $this->getContainer());
@@ -427,6 +431,10 @@ class SncRedisExtensionTest extends TestCase
      */
     public function testPhpRedisDuplicatedParameters()
     {
+        if (!class_exists('\\Redis', false)) {
+            $this->markTestSkipped('This test needs the PHP Redis extension to work');
+        }
+
         $extension = new SncRedisExtension();
         $config = $this->parseYaml($this->getPhpRedisYamlConfigWithDuplicatedParameters());
         $extension->load(array($config), $container = $this->getContainer());

--- a/Tests/Functional/App/config.yaml
+++ b/Tests/Functional/App/config.yaml
@@ -4,11 +4,14 @@ framework:
     default_locale: en
     profiler: { collect: true }
     session:
-        storage_id:     session.storage.mock_file
+        storage_id: session.storage.mock_file
 
 web_profiler:
     toolbar: false
     intercept_redirects: false
+
+twig:
+    strict_variables: '%kernel.debug%'
 
 doctrine:
     dbal:

--- a/Tests/Functional/IntegrationTest.php
+++ b/Tests/Functional/IntegrationTest.php
@@ -15,6 +15,7 @@ namespace Snc\RedisBundle\Tests\Functional;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Tools\SchemaTool;
+use PHPUnit\Framework\SkippedTestSuiteError;
 use Snc\RedisBundle\Command\RedisFlushallCommand;
 use Snc\RedisBundle\DataCollector\RedisDataCollector;
 use Snc\RedisBundle\Tests\Functional\App\Kernel;
@@ -86,6 +87,10 @@ class IntegrationTest extends WebTestCase
     public static function setUpBeforeClass()
     {
         static::deleteTmpDir();
+
+        if (!class_exists('\\Redis', false)) {
+            throw new SkippedTestSuiteError('This test needs the PHP Redis extension to work');
+        }
 
         $kernel = static::createClient()->getKernel();
 


### PR DESCRIPTION
This follows the Symfony documention for creating & managing service locators:
https://symfony.com/doc/3.4/service_container/service_subscribers_locators.html#defining-a-service-locator

Fixes #520 