### PR TITLE
No longer use curly brackets for substring

### DIFF
--- a/DependencyInjection/Configuration/RedisDsn.php
+++ b/DependencyInjection/Configuration/RedisDsn.php
@@ -190,7 +190,7 @@ class RedisDsn
         if (preg_match('#^([^:]+)(:(\d+|%[^%]+%))?$#', $dsn, $matches)) {
             if (!empty($matches[1])) {
                 // parse host/ip or socket
-                if ('/' === $matches[1]{0}) {
+                if ('/' === $matches[1][0]) {
                     $this->socket = $matches[1];
                 } else {
                     $this->host = $matches[1];


### PR DESCRIPTION
It has been deprecated since PHP 7.4

See https://wiki.php.net/rfc/deprecate_curly_braces_array_access