### PR TITLE
Invalid argument supplied for foreach() fix 

### DIFF
--- a/DependencyInjection/Configuration/Configuration.php
+++ b/DependencyInjection/Configuration/Configuration.php
@@ -95,11 +95,14 @@ class Configuration implements ConfigurationInterface
                     ->beforeNormalization()
                         ->always()
                         ->then(function($v) {
-                            foreach ($v as $name => &$client) {
-                                if (!isset($client['alias'])) {
-                                    $client['alias'] = $name;
+                            if (is_iterable($v)) {
+                                foreach ($v as $name => &$client) {
+                                    if (!isset($client['alias'])) {
+                                        $client['alias'] = $name;
+                                    }
                                 }
                             }
+
                             return $v;
                         })
                     ->end()


### PR DESCRIPTION
Added simple condition to get rid of Warning: Invalid argument supplied for foreach() error. After this change, if you don't have any defined clients in config you'll end with no redis clients found (tag name: snc_redis.client) error.

Experienced this just after installing the bundle, when composer tries to exec bin/console cache:clear.
PHP 7.3, Symfony 4.3