### PR TITLE
Fix check for connection_persistent with phpredis factory

### DIFF
--- a/Factory/PhpredisClientFactory.php
+++ b/Factory/PhpredisClientFactory.php
@@ -55,7 +55,7 @@ class PhpredisClientFactory
             $connectParameters[] = null;
         }
 
-        if (isset($options['connection_persistent'])) {
+        if (!empty($options['connection_persistent'])) {
             $connectParameters[] = $parsedDsn->getPersistentId();
         }
 


### PR DESCRIPTION
Fixes #537 

This condition is now exactly the same as the one to check for connection method, see https://github.com/snc/SncRedisBundle/blob/86b5d1e4a82701bb172800106bb1c719a03bb1bd/Factory/PhpredisClientFactory.php#L62