### PR TITLE
Ensure compatibility with Symfony 4.4 (fix #461)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,7 @@ matrix:
     - php: 7.3
       env: SYMFONY_VERSION="4.3.*""
     - php: 7.3
-      env: SYMFONY_VERSION="4.4.*" STABILITY="dev"
-  allow_failures:
-    - env: SYMFONY_VERSION="4.4.*" STABILITY="dev"
+      env: SYMFONY_VERSION="4.4.*" STABILITY="dev" SYMFONY_DEPRECATIONS_HELPER="max[self]=3"
 
 dist: xenial
 sudo: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## Next release
+
+- Deprecate support for redis profiler storage
+
 ## [3.1.1](https://github.com/snc/SncRedisBundle/tree/3.1.1) (2019-10-09)
 [Full Changelog](https://github.com/snc/SncRedisBundle/compare/3.1.0...3.1.1)
 

--- a/Command/RedisBaseCommand.php
+++ b/Command/RedisBaseCommand.php
@@ -79,10 +79,10 @@ abstract class RedisBaseCommand extends Command
             $this->redisClient = $this->clientLocator->get('snc_redis.' . $client);
         } catch (ServiceNotFoundException $e) {
             $this->output->writeln('<error>The client "' . $client . '" is not defined</error>');
-            return;
+            return 0;
         }
 
-        $this->executeRedisCommand();
+        return $this->executeRedisCommand();
     }
 
     /**

--- a/Command/RedisFlushallCommand.php
+++ b/Command/RedisFlushallCommand.php
@@ -38,7 +38,10 @@ class RedisFlushallCommand extends RedisBaseCommand
             $this->flushAll();
         } else {
             $this->output->writeln('<error>Flushing cancelled</error>');
+            return 1;
         }
+
+        return 0;
     }
 
     /**

--- a/Command/RedisFlushdbCommand.php
+++ b/Command/RedisFlushdbCommand.php
@@ -38,7 +38,11 @@ class RedisFlushdbCommand extends RedisBaseCommand
             $this->flushDbForClient();
         } else {
             $this->output->writeln('<error>Flushing cancelled</error>');
+
+            return 1;
         }
+
+        return 0;
     }
 
     /**

--- a/DependencyInjection/Configuration/Configuration.php
+++ b/DependencyInjection/Configuration/Configuration.php
@@ -17,8 +17,6 @@ use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 /**
- * RedisBundle configuration class.
- *
  * @author Henrik Westphal <henrik.westphal@gmail.com>
  */
 class Configuration implements ConfigurationInterface
@@ -269,6 +267,7 @@ class Configuration implements ConfigurationInterface
         $rootNode
             ->children()
                 ->arrayNode('profiler_storage')
+                    ->setDeprecated('Redis profiler storage is not available anymore since Symfony 4.4')
                     ->canBeUnset()
                     ->children()
                         ->scalarNode('client')->isRequired()->end()

--- a/DependencyInjection/SncRedisExtension.php
+++ b/DependencyInjection/SncRedisExtension.php
@@ -439,7 +439,7 @@ class SncRedisExtension extends Extension
     protected function loadProfilerStorage(array $config, ContainerBuilder $container, XmlFileLoader $loader)
     {
         if (Kernel::VERSION_ID >= 40400) {
-            @trigger_error('Redis profiler storage is not available anymore since Symfony 4.4', E_USER_WARNING);
+            @trigger_error('Redis profiler storage is not available anymore since Symfony 4.4. The option has been disabled automatically.', E_USER_WARNING);
 
             return;
         }

--- a/DependencyInjection/SncRedisExtension.php
+++ b/DependencyInjection/SncRedisExtension.php
@@ -25,6 +25,7 @@ use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
 use Snc\RedisBundle\Factory\PhpredisClientFactory;
 use Predis\Command\Processor\KeyPrefixProcessor;
+use Symfony\Component\HttpKernel\Kernel;
 
 class SncRedisExtension extends Extension
 {
@@ -437,6 +438,12 @@ class SncRedisExtension extends Extension
      */
     protected function loadProfilerStorage(array $config, ContainerBuilder $container, XmlFileLoader $loader)
     {
+        if (Kernel::VERSION_ID >= 40400) {
+            @trigger_error('Redis profiler storage is not available anymore since Symfony 4.4', E_USER_WARNING);
+
+            return;
+        }
+
         $loader->load('profiler_storage.xml');
 
         $container->setParameter('snc_redis.profiler_storage.client', $config['profiler_storage']['client']);

--- a/Profiler/Storage/RedisProfilerStorage.php
+++ b/Profiler/Storage/RedisProfilerStorage.php
@@ -15,6 +15,8 @@ use Symfony\Component\HttpKernel\Profiler\Profile;
 use Symfony\Component\HttpKernel\Profiler\ProfilerStorageInterface;
 
 /**
+ * @deprecated since version 3.2.0 as \Symfony\Component\HttpKernel\Profiler\ProfilerStorageInterface is now marked as internal
+ *
  * RedisProfilerStorage stores profiling information in Redis.
  *
  * This class is a reimplementation of

--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -316,18 +316,9 @@ swiftmailer:
 
 ### Profiler storage ###
 
-To store your profiler data in Redis for Symfony 3 add following to your config:
+:warning: this feature is not supported anymore since Symfony 4.4 and will be automatically disabled if you are using Symfony 4.4.
 
-``` yaml
-snc_redis:
-    ...
-    profiler_storage:
-        client: profiler_storage
-        ttl: 3600
-```
-
-This will overwrite the `profiler.storage` service.
-Prior to [Symfony 3.0 support for Redis was built-in](http://symfony.com/doc/current/profiler/storage.html).
+>As the profiler must only be used on non-production servers, the file storage is more than enough and no other implementations will ever be supported. 
 
 ### Complete configuration example ###
 
@@ -344,11 +335,6 @@ snc_redis:
             alias: cache
             dsn: redis://localhost/1
             logging: false
-        profiler_storage:
-            type: predis
-            alias: profiler_storage
-            dsn: redis://localhost/2
-            logging: true
         cluster:
             type: predis
             alias: cluster
@@ -391,9 +377,6 @@ snc_redis:
     swiftmailer:
         client: default
         key: swiftmailer
-    profiler_storage:
-        client: profiler_storage
-        ttl: 3600
 ```
 
 ## Usage with `symfony/web-profiler-bundle`

--- a/Tests/Functional/App/config.yaml
+++ b/Tests/Functional/App/config.yaml
@@ -6,6 +6,9 @@ framework:
     session:
         storage_id:     session.storage.mock_file
 
+twig:
+    strict_variables: true
+
 web_profiler:
     toolbar: false
     intercept_redirects: false
@@ -37,11 +40,6 @@ snc_redis:
             alias: cache
             dsn: redis://localhost/1
             logging: false
-        profiler_storage:
-            type: predis
-            alias: profiler_storage
-            dsn: redis://localhost/2
-            logging: true
         cluster:
             type: predis
             alias: cluster
@@ -83,9 +81,6 @@ snc_redis:
     swiftmailer:
         client: default
         key: swiftmailer
-    profiler_storage:
-        client: profiler_storage
-        ttl: 3600
 
 services:
     _defaults:

--- a/Tests/Profiler/Storage/RedisProfilerStorageTest.php
+++ b/Tests/Profiler/Storage/RedisProfilerStorageTest.php
@@ -17,6 +17,9 @@ use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\HttpKernel\Profiler\Profile;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @group legacy
+ */
 class RedisProfilerStorageTest extends TestCase
 {
     protected static $storage;

--- a/Tests/Profiler/Storage/RedisProfilerStorageTest.php
+++ b/Tests/Profiler/Storage/RedisProfilerStorageTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\HttpKernel\Tests\Profiler;
 
 use Snc\RedisBundle\Profiler\Storage\RedisProfilerStorage;
 use Snc\RedisBundle\Tests\Profiler\Storage\Mock\RedisMock;
+use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\HttpKernel\Profiler\Profile;
 use PHPUnit\Framework\TestCase;
 
@@ -22,6 +23,11 @@ class RedisProfilerStorageTest extends TestCase
 
     protected function setUp()
     {
+        if (Kernel::VERSION_ID >= 40400) {
+            $this->markTestSkipped('Redis profiler storage is not supported since Symfony 4.4');
+        }
+
+
         $redisMock = new RedisMock();
         $redisMock->connect('127.0.0.1', 6379);
 

--- a/UPDATE.md
+++ b/UPDATE.md
@@ -1,5 +1,9 @@
 # Update notes #
 
+## 4.0.0 ##
+
+- Removed redis profiler storage feature `snc_redis.profiler_storage`
+
 ## 3.0.0 ##
 
 - Bumped Symfony minimum version to 3.4


### PR DESCRIPTION
fix #461

As per Symfony:
>This interface exists for historical reasons. The only supported
>implementation is FileProfilerStorage.
>As the profiler must only be used on non-production servers, the file storage
>is more than enough and no other implementations will ever be supported.