### PR TITLE
Support for connection parameters

### DIFF
--- a/DependencyInjection/SncRedisExtension.php
+++ b/DependencyInjection/SncRedisExtension.php
@@ -160,6 +160,9 @@ class SncRedisExtension extends Extension
         unset($client['options']['connection_timeout']);
         unset($client['options']['connection_persistent']);
         unset($client['options']['throw_errors']);
+        
+        // It seems like a change in newer predis versions. Parameters have to be in the options layer
+        $client['options'] = array_merge($client['options'], $client['options']['parameters']);
 
         $connectionAliases = array();
         $connectionCount = count($client['dsns']);

--- a/DependencyInjection/SncRedisExtension.php
+++ b/DependencyInjection/SncRedisExtension.php
@@ -162,7 +162,9 @@ class SncRedisExtension extends Extension
         unset($client['options']['throw_errors']);
         
         // It seems like a change in newer predis versions. Parameters have to be in the options layer
-        $client['options'] = array_merge($client['options'], $client['options']['parameters']);
+        if(isset($client['options']['parameters'])) {
+            $client['options'] = array_merge($client['options'], $client['options']['parameters']);
+        }
 
         $connectionAliases = array();
         $connectionCount = count($client['dsns']);


### PR DESCRIPTION
In newer versions connection parameters have to be in the options layer.
For bc the parameters layer not removed.

Related: https://github.com/snc/SncRedisBundle/issues/513