### PR TITLE
Current Master: Support for connection parameters

### DIFF
--- a/DependencyInjection/SncRedisExtension.php
+++ b/DependencyInjection/SncRedisExtension.php
@@ -165,6 +165,11 @@ class SncRedisExtension extends Extension
         unset($client['options']['connection_timeout']);
         unset($client['options']['connection_persistent']);
         unset($client['options']['throw_errors']);
+        
+        // It seems like a change in newer predis versions. Parameters have to be in the options layer
+        if(isset($client['options']['parameters'])) {
+            $client['options'] = array_merge($client['options'], $client['options']['parameters']);
+        }
 
         $connectionAliases = array();
         $connectionCount = count($client['dsns']);


### PR DESCRIPTION
In newer versions connection parameters have to be in the options layer.
For bc the parameters layer not removed.