### PR TITLE
Handle default database for persistent connection

### DIFF
--- a/Factory/PredisParametersFactory.php
+++ b/Factory/PredisParametersFactory.php
@@ -27,7 +27,10 @@ class PredisParametersFactory
         $dsnOptions = static::parseDsn(new RedisDsn($dsn));
         $dsnOptions = array_merge($defaultOptions, $options, $dsnOptions);
 
-        if (isset($dsnOptions['persistent'], $dsnOptions['database']) && true === $dsnOptions['persistent']) {
+        if (isset($dsnOptions['persistent'], $dsnOptions['database'])
+            && true === $dsnOptions['persistent']
+            && (int)$dsnOptions['database'] !== 0
+        ) {
             $dsnOptions['persistent'] = (int)$dsnOptions['database'];
         }
 

--- a/Tests/Factory/PredisParametersFactoryTest.php
+++ b/Tests/Factory/PredisParametersFactoryTest.php
@@ -107,6 +107,17 @@ class PredisParametersFactoryTest extends TestCase
                     'timeout' => null,
                 )
             ),
+            [
+                'redis://localhost/0',
+                'Predis\Connection\Parameters',
+                [
+                    'persistent' => true
+                ],
+                [
+                    'persistent' => true,
+                    'database' => 0
+                ]
+            ]
         );
     }
 


### PR DESCRIPTION
This change is a fix for change #462 . Specifying both default database (as 0) and persistent (as true) results in falsy persistent setting. In mentioned PR, there is a mentioned predis change, which works only if persistent key is not boolean.

Since we are interested in `persistent => true` cases, it is required to check if mentioned database is falsy or not.