### PR TITLE
[Docs] Added example for use with Symfony Cache Pools.

### DIFF
--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -314,6 +314,23 @@ swiftmailer:
         type: redis
 ```
 
+### Symfony Cache Pools ###
+
+If you want to use one of the client connections for the Symfony App Cache or a Symfony Cache Pool, just use its service name as a cache pool provider:
+
+```yaml
+framework:
+    cache:
+        app: cache.adapter.redis
+        # app cache from client config as default adapter/provider
+        default_redis_provider: snc_redis.default
+    pools:
+        some-pool.cache:
+            adapter: cache.adapter.redis
+            # a specific provider, e.g. if you have a snc_redis.clients.cache
+            provider: snc_redis.cache
+```
+
 ### Profiler storage ###
 
 :warning: this feature is not supported anymore since Symfony 4.4 and will be automatically disabled if you are using Symfony 4.4.


### PR DESCRIPTION
Took the [comment](https://github.com/snc/SncRedisBundle/issues/291#issuecomment-249495928) from #291 and placed it in the docs. Would have saved me half a day, if I had recognized this earlier.

Fixes #291, hopefully.