### PR TITLE
Deprecation since Symfony 5.1: NodeDefinition::setDeprecated() requires 3 arguments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ matrix:
       env: SYMFONY_VERSION="4.4.*"
     - php: 7.4
       env: SYMFONY_VERSION="5.0.*"
+    - php: 7.2
+      env: SYMFONY_VERSION="5.1.*"
     - php: 7.4
       env: SYMFONY_VERSION="5.1.*"
     - php: 7.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,11 +17,13 @@ matrix:
     - php: 7.4
       env: SYMFONY_VERSION="5.0.*"
     - php: 7.4
-      env: SYMFONY_VERSION="5.1.*" STABILITY="dev"
+      env: SYMFONY_VERSION="5.1.*"
+    - php: 7.4
+      env: SYMFONY_VERSION="5.2.*" STABILITY="dev"
 
   allow_failures:
     - php: 7.4
-      env: SYMFONY_VERSION="5.1.*" STABILITY="dev"
+      env: SYMFONY_VERSION="5.2.*" STABILITY="dev"
 
 dist: xenial
 sudo: false

--- a/DependencyInjection/Configuration/Configuration.php
+++ b/DependencyInjection/Configuration/Configuration.php
@@ -11,6 +11,7 @@
 
 namespace Snc\RedisBundle\DependencyInjection\Configuration;
 
+use Symfony\Component\Config\Definition\BaseNode;
 use function method_exists;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
@@ -267,7 +268,7 @@ class Configuration implements ConfigurationInterface
         $rootNode
             ->children()
                 ->arrayNode('profiler_storage')
-                    ->setDeprecated('Redis profiler storage is not available anymore since Symfony 4.4')
+                    ->setDeprecated(...$this->getProfilerStorageDeprecationMessage())
                     ->canBeUnset()
                     ->children()
                         ->scalarNode('client')->isRequired()->end()
@@ -275,5 +276,24 @@ class Configuration implements ConfigurationInterface
                     ->end()
                 ->end()
             ->end();
+    }
+
+    /**
+     * Keep compatibility with symfony/config < 5.1
+     * 
+     * The signature of method NodeDefinition::setDeprecated() has been updated to 
+     * NodeDefinition::setDeprecation(string $package, string $version, string $message).
+     * 
+     * @return array
+     */
+    private function getProfilerStorageDeprecationMessage(): array
+    {
+        $message = 'Redis profiler storage is not available anymore since Symfony 4.4';
+
+        if (method_exists(BaseNode::class, 'getDeprecation')) {
+            return ['snc/redis-bundle', '3.2.0', $message];
+        }
+        
+        return [$message];
     }
 }

--- a/Tests/Functional/App/Controller/Controller.php
+++ b/Tests/Functional/App/Controller/Controller.php
@@ -29,7 +29,7 @@ class Controller extends AbstractController
     {
         $redis->set('foo', 'bar');
 
-        return JsonResponse::create([
+        return new JsonResponse([
             'result' => $redis->get('foo'),
         ]);
     }
@@ -45,7 +45,7 @@ class Controller extends AbstractController
         $em->persist($user);
         $em->flush();
 
-        return JsonResponse::create(['result' => 'ok']);
+        return new JsonResponse(['result' => 'ok']);
     }
 
     public function viewUser()
@@ -55,7 +55,7 @@ class Controller extends AbstractController
         /** @var User $user */
         $user = $repository->findOneBy(['username' => 'foo']);
 
-        return JsonResponse::create([
+        return new JsonResponse([
             'id' => $user->getId(),
             'username' => $user->getUsername(),
             'email' => $user->getEmail(),


### PR DESCRIPTION
The signature of method `NodeDefinition::setDeprecated()` has been updated to `NodeDefinition::setDeprecation(string $package, string $version, string $message)`.

See https://github.com/symfony/symfony/blob/5.1/UPGRADE-5.1.md