### PR TITLE
Support phpredis 5.2.1

### DIFF
--- a/Client/Phpredis/Client.php
+++ b/Client/Phpredis/Client.php
@@ -1074,7 +1074,7 @@ class Client extends Redis
     /**
      * {@inheritdoc}
      */
-    public function zAdd($key, $score1, $value1, $score2 = null, $value2 = null, $scoreN = null, $valueN = null)
+    public function zAdd($key, $score, $value, ...$extra_args)
     {
         return $this->call('zAdd', func_get_args());
     }


### PR DESCRIPTION
A simple commit to fix the declaration of `zAdd()` for phpredis 5.2.1. This commit is backward compatible with older versions of phpredis since it only adds an argument to the function: https://github.com/phpredis/phpredis/commit/977c4213c190bb1fc43782d757d8d386eb42015e

Fixes #583