### PR TITLE
Fix Symfony cache pool example

### DIFF
--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -324,11 +324,11 @@ framework:
         app: cache.adapter.redis
         # app cache from client config as default adapter/provider
         default_redis_provider: snc_redis.default
-    pools:
-        some-pool.cache:
-            adapter: cache.adapter.redis
-            # a specific provider, e.g. if you have a snc_redis.clients.cache
-            provider: snc_redis.cache
+        pools:
+            some-pool.cache:
+                adapter: cache.adapter.redis
+                # a specific provider, e.g. if you have a snc_redis.clients.cache
+                provider: snc_redis.cache
 ```
 
 ### Profiler storage ###


### PR DESCRIPTION
The Symfony cache pool example configuration is invalid:
```
Unrecognized option "pools" under "framework". Available options are "annotations", "assets", "cache", "csrf_protection", "default_locale", "disallow_search_engine_index", "error_controller", "esi", "form", "fragments", "http_client", "http_method_override", "ide", "lock", "mailer", "messenger", "notifier", "php_errors", "profiler", "property_access", "property_info", "request", "router", "secret", "secrets", "serializer", "session", "ssi", "test", "translator", "trusted_hosts", "validation", "web_link", "workflows".
```


In order to have the intended effect, the `pools` block has to be under `framework.cache`. This PR should fix the issue.