### PR TITLE
Specify the password via parameters for non sentinel connections

### DIFF
--- a/Factory/PredisParametersFactory.php
+++ b/Factory/PredisParametersFactory.php
@@ -40,7 +40,8 @@ class PredisParametersFactory
         }
 
         if (
-            !isset($finalOptions['replication'])
+            !isset($finalOptions['password'])
+            && !isset($finalOptions['replication'])
             && isset($finalOptions['parameters']['password'])
         ) {
             $finalOptions['password'] = $finalOptions['parameters']['password'];

--- a/Factory/PredisParametersFactory.php
+++ b/Factory/PredisParametersFactory.php
@@ -41,7 +41,7 @@ class PredisParametersFactory
 
         if (
             !isset($finalOptions['password'])
-            && !isset($finalOptions['replication'])
+            && (!isset($finalOptions['replication']) || $finalOptions['replication'] === false)
             && isset($finalOptions['parameters']['password'])
         ) {
             $finalOptions['password'] = $finalOptions['parameters']['password'];

--- a/Tests/Factory/PredisParametersFactoryTest.php
+++ b/Tests/Factory/PredisParametersFactoryTest.php
@@ -207,9 +207,11 @@ class PredisParametersFactoryTest extends TestCase
         $this->assertObjectNotHasAttribute('user', $parameters);
     }
 
+    /**
+     * @expectedException InvalidArgumentException
+     */
     public function testCreateException()
     {
-        $this->expectException(new InvalidArgumentException());
         PredisParametersFactory::create(array(), '\stdClass', 'redis://localhost');
     }
 }

--- a/Tests/Factory/PredisParametersFactoryTest.php
+++ b/Tests/Factory/PredisParametersFactoryTest.php
@@ -164,7 +164,7 @@ class PredisParametersFactoryTest extends TestCase
                 )
             ),
 
-            // If replication is disabled the password should be in parameters->parameters->password
+            // If replication is enabled the password should be in parameters->parameters->password
             array(
                 'redis://localhost',
                 'Predis\Connection\Parameters',


### PR DESCRIPTION
Before this change, the options:parameters:password was reserved for sentinel
connections only, as we need a way to pass the auth to the servers that
sentinel provides for us, but not to sentinel itself.

This change allows us to use options:parameters:password for regular redis
connections.

The code checks if replication is set, because we want to keep the sentinel
functionality as is, which in this case is to leave the password in parameters
and allow sentinel to build the connection later.