### PR TITLE
Support nested DSNs generated by process environment variables

### DIFF
--- a/Factory/PhpredisClientFactory.php
+++ b/Factory/PhpredisClientFactory.php
@@ -44,6 +44,9 @@ class PhpredisClientFactory
             throw new \LogicException(sprintf('The factory can only instantiate \Redis|\RedisCluster classes: "%s" asked', $class));
         }
 
+        // Normalize the DSNs, because using processed environment variables could lead to nested values.
+        $dsns = count($dsns) === 1 && is_array($dsns[0]) ? $dsns[0] : $dsns;
+
         $parsedDsns = array_map(static function (string $dsn) {
             return new RedisDsn($dsn);
         }, $dsns);

--- a/Tests/Factory/PhpredisClientFactoryTest.php
+++ b/Tests/Factory/PhpredisClientFactoryTest.php
@@ -110,4 +110,26 @@ class PhpredisClientFactoryTest extends TestCase
         $this->assertSame('pass', $client->getAuth());
         $this->assertNull($client->getPersistentID());
     }
+
+    public function testNestedDsnConfig()
+    {
+        $factory = new PhpredisClientFactory();
+
+        $client = $factory->create(
+            \Redis::class,
+            [['redis://redis:pass@localhost:6379/2']],
+            array(
+                'parameters' => [
+                    'database' => 3,
+                    'password' => 'secret',
+                ],
+            ),
+            'alias_test'
+        );
+
+        $this->assertInstanceOf(\Redis::class, $client);
+        $this->assertSame(2, $client->getDBNum());
+        $this->assertSame('pass', $client->getAuth());
+        $this->assertNull($client->getPersistentID());
+    }
 }


### PR DESCRIPTION
I was trying to use this config for a project:

```yaml
snc_redis:
    clients:
        default:
            type: phpredis
            alias: default
            dsn: "%env(csv:REDIS_URL)%"
            options:
                cluster: true
```

This allows to use a simple list of redis instances in one env var:

```
REDIS_URL=redis://host_1,redis://host_2
```

However, when the processed environment variable returns an array, the `PhpredisClientFactory` receives the following DSN config:

```php
array (
  0 => 
  array (
    0 => 'redis://host_1',
    1 => 'redis://host_2',
  ),
)
```

This is difficult to solve in the configuration processor because the environment variable is stored as a simple string placeholder and not with the real and final value, so we can't detect the type of the value.

The solution is to detect, inside the `PhpredisClientFactory` class, if the DSN config contains only one item and if the first item is an array, then we simply use the nested array as the whole DSN config.