### PR TITLE
Add support for PHP 8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 /build/
 /composer.lock
 /composer.phar
+/.phpunit.result.cache
 /vendor/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 language: php
 
-services:
-  - redis-server
-
 matrix:
   fast_finish: true
   include:
@@ -48,6 +45,7 @@ before_install:
   - composer global require --no-progress --no-scripts --no-plugins symfony/flex
   - if ! [ -z "${STABILITY}" ]; then composer config minimum-stability ${STABILITY}; fi;
   - if [ "${SYMFONY_VERSION}" != "" ]; then composer config extra.symfony.require ${SYMFONY_VERSION}; fi;
+  - sudo redis-server --requirepass sncredis --daemonize yes
   - for PORT in {7000..7008}; do sudo redis-server --port ${PORT} --cluster-enabled yes --cluster-config-file ${PORT}.conf --daemonize yes; echo 127.0.0.1:${PORT}; done
   - echo yes | redis-cli --cluster create $(seq -f 127.0.0.1:%g 7000 7008) --cluster-replicas 2
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,15 +12,25 @@ matrix:
       env: SYMFONY_VERSION="4.4.*"
     - php: 7.4
       env: SYMFONY_VERSION="4.4.*"
+    - php: 8.0
+      env: SYMFONY_VERSION="4.4.*"
     - php: 7.4
+      env: SYMFONY_VERSION="5.0.*"
+    - php: 8.0
       env: SYMFONY_VERSION="5.0.*"
     - php: 7.4
       env: SYMFONY_VERSION="5.1.*"
+    - php: 8.0
+      env: SYMFONY_VERSION="5.1.*"
     - php: 7.4
+      env: SYMFONY_VERSION="5.2.*" STABILITY="dev"
+    - php: 8.0
       env: SYMFONY_VERSION="5.2.*" STABILITY="dev"
 
   allow_failures:
     - php: 7.4
+      env: SYMFONY_VERSION="5.2.*" STABILITY="dev"
+    - php: 8.0
       env: SYMFONY_VERSION="5.2.*" STABILITY="dev"
 
 dist: bionic

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,18 +6,14 @@ services:
 matrix:
   fast_finish: true
   include:
-    - php: 7.1
+    - php: 7.3
       env: SYMFONY_VERSION="3.4.*" COMPOSER_FLAGS="--prefer-lowest"
-    - php: 7.2
-      env: SYMFONY_VERSION="4.4.*"
     - php: 7.3
       env: SYMFONY_VERSION="4.4.*"
     - php: 7.4
       env: SYMFONY_VERSION="4.4.*"
     - php: 7.4
       env: SYMFONY_VERSION="5.0.*"
-    - php: 7.2
-      env: SYMFONY_VERSION="5.1.*"
     - php: 7.4
       env: SYMFONY_VERSION="5.1.*"
     - php: 7.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,10 @@ language: php
 matrix:
   fast_finish: true
   include:
-    - php: 7.3
+    - php: 7.2
       env: SYMFONY_VERSION="3.4.*" COMPOSER_FLAGS="--prefer-lowest"
+    - php: 7.2
+      env: SYMFONY_VERSION="4.4.*"
     - php: 7.3
       env: SYMFONY_VERSION="4.4.*"
     - php: 7.4
@@ -15,6 +17,8 @@ matrix:
       env: SYMFONY_VERSION="5.0.*"
     - php: 8.0
       env: SYMFONY_VERSION="5.0.*"
+    - php: 7.2
+      env: SYMFONY_VERSION="5.1.*"
     - php: 7.4
       env: SYMFONY_VERSION="5.1.*"
     - php: 8.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,15 +23,9 @@ matrix:
     - php: 8.0
       env: SYMFONY_VERSION="5.1.*"
     - php: 7.4
-      env: SYMFONY_VERSION="5.2.*" STABILITY="dev"
+      env: SYMFONY_VERSION="5.2.*"
     - php: 8.0
-      env: SYMFONY_VERSION="5.2.*" STABILITY="dev"
-
-  allow_failures:
-    - php: 7.4
-      env: SYMFONY_VERSION="5.2.*" STABILITY="dev"
-    - php: 8.0
-      env: SYMFONY_VERSION="5.2.*" STABILITY="dev"
+      env: SYMFONY_VERSION="5.2.*"
 
 dist: bionic
 sudo: false

--- a/DependencyInjection/Compiler/SwiftMailerPass.php
+++ b/DependencyInjection/Compiler/SwiftMailerPass.php
@@ -36,7 +36,7 @@ class SwiftMailerPass implements CompilerPassInterface
                 // default class, lets check for Swift Mailer version and set correct class
                 $class = new \ReflectionClass('\\Swift_Spool');
                 $parameters = $class->getMethod('queueMessage')->getParameters();
-                switch ($parameters[0]->getClass()->getName()) {
+                switch ($parameters[0]->getType()) {
                     case 'Swift_Mime_Message':
                         // Swift Mailer 5.x
                         $handlerDefinition->setClass($handlerDefinition->getClass().'5');

--- a/Tests/Client/Phpredis/ClientClusterTest.php
+++ b/Tests/Client/Phpredis/ClientClusterTest.php
@@ -7,7 +7,7 @@ use Snc\RedisBundle\Client\Phpredis\ClientCluster;
 
 class ClientClusterTest extends TestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         if (!extension_loaded('redis')) {
             $this->markTestSkipped('This test needs the PHP Redis extension to work');

--- a/Tests/Command/CommandTestCase.php
+++ b/Tests/Command/CommandTestCase.php
@@ -48,7 +48,7 @@ abstract class CommandTestCase extends TestCase
     /**
      * SetUp called before each tests, setting up the environment (application, globally used mocks)
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->container = $this->getMockBuilder('\\Symfony\\Component\\DependencyInjection\\ContainerInterface')->getMock();
 

--- a/Tests/Command/RedisFlushAllCommandTest.php
+++ b/Tests/Command/RedisFlushAllCommandTest.php
@@ -64,7 +64,7 @@ class RedisFlushallCommandTest extends CommandTestCase
         $commandTester = new CommandTester($command);
         $commandTester->execute(array('command' => $command->getName(), '--no-interaction' => true));
 
-        $this->assertMatchesRegularExpression('/All redis databases flushed/', $commandTester->getDisplay());
+        $this->assertRegExp('/All redis databases flushed/', $commandTester->getDisplay());
     }
 
     public function testClientOption()
@@ -104,7 +104,7 @@ class RedisFlushallCommandTest extends CommandTestCase
         $commandTester = new CommandTester($command);
         $commandTester->execute(array('command' => $command->getName(), '--client' => 'special', '--no-interaction' => true));
 
-        $this->assertMatchesRegularExpression('/All redis databases flushed/', $commandTester->getDisplay());
+        $this->assertRegExp('/All redis databases flushed/', $commandTester->getDisplay());
     }
 
     public function testClientOptionWithNotExistingClient()
@@ -123,7 +123,7 @@ class RedisFlushallCommandTest extends CommandTestCase
         $commandTester = new CommandTester($command);
         $commandTester->execute(array('command' => $command->getName(), '--client' => 'notExisting', '--no-interaction' => true));
 
-        $this->assertMatchesRegularExpression('/The client "notExisting" is not defined/', $commandTester->getDisplay());
+        $this->assertRegExp('/The client "notExisting" is not defined/', $commandTester->getDisplay());
     }
 
     public function testBugFixInPredis()
@@ -150,7 +150,7 @@ class RedisFlushallCommandTest extends CommandTestCase
         $commandTester = new CommandTester($command);
         $commandTester->execute(array('command' => $command->getName(), '--no-interaction' => true));
 
-        $this->assertMatchesRegularExpression('/All redis databases flushed/', $commandTester->getDisplay());
+        $this->assertRegExp('/All redis databases flushed/', $commandTester->getDisplay());
     }
 
     protected function getCommand()

--- a/Tests/Command/RedisFlushAllCommandTest.php
+++ b/Tests/Command/RedisFlushAllCommandTest.php
@@ -20,7 +20,7 @@ use Snc\RedisBundle\Command\RedisFlushallCommand;
 class RedisFlushallCommandTest extends CommandTestCase
 {
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -64,7 +64,7 @@ class RedisFlushallCommandTest extends CommandTestCase
         $commandTester = new CommandTester($command);
         $commandTester->execute(array('command' => $command->getName(), '--no-interaction' => true));
 
-        $this->assertRegExp('/All redis databases flushed/', $commandTester->getDisplay());
+        $this->assertMatchesRegularExpression('/All redis databases flushed/', $commandTester->getDisplay());
     }
 
     public function testClientOption()
@@ -104,7 +104,7 @@ class RedisFlushallCommandTest extends CommandTestCase
         $commandTester = new CommandTester($command);
         $commandTester->execute(array('command' => $command->getName(), '--client' => 'special', '--no-interaction' => true));
 
-        $this->assertRegExp('/All redis databases flushed/', $commandTester->getDisplay());
+        $this->assertMatchesRegularExpression('/All redis databases flushed/', $commandTester->getDisplay());
     }
 
     public function testClientOptionWithNotExistingClient()
@@ -123,7 +123,7 @@ class RedisFlushallCommandTest extends CommandTestCase
         $commandTester = new CommandTester($command);
         $commandTester->execute(array('command' => $command->getName(), '--client' => 'notExisting', '--no-interaction' => true));
 
-        $this->assertRegExp('/The client "notExisting" is not defined/', $commandTester->getDisplay());
+        $this->assertMatchesRegularExpression('/The client "notExisting" is not defined/', $commandTester->getDisplay());
     }
 
     public function testBugFixInPredis()
@@ -150,7 +150,7 @@ class RedisFlushallCommandTest extends CommandTestCase
         $commandTester = new CommandTester($command);
         $commandTester->execute(array('command' => $command->getName(), '--no-interaction' => true));
 
-        $this->assertRegExp('/All redis databases flushed/', $commandTester->getDisplay());
+        $this->assertMatchesRegularExpression('/All redis databases flushed/', $commandTester->getDisplay());
     }
 
     protected function getCommand()

--- a/Tests/Command/RedisFlushdbCommandTest.php
+++ b/Tests/Command/RedisFlushdbCommandTest.php
@@ -20,7 +20,7 @@ use Snc\RedisBundle\Command\RedisFlushdbCommand;
 class RedisFlushdbCommandTest extends CommandTestCase
 {
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -64,7 +64,7 @@ class RedisFlushdbCommandTest extends CommandTestCase
         $commandTester = new CommandTester($command);
         $commandTester->execute(array('command' => $command->getName(), '--no-interaction' => true));
 
-        $this->assertRegExp('/redis database flushed/', $commandTester->getDisplay());
+        $this->assertMatchesRegularExpression('/redis database flushed/', $commandTester->getDisplay());
     }
 
     public function testClientOption()
@@ -104,7 +104,7 @@ class RedisFlushdbCommandTest extends CommandTestCase
         $commandTester = new CommandTester($command);
         $commandTester->execute(array('command' => $command->getName(), '--client' => 'special', '--no-interaction' => true));
 
-        $this->assertRegExp('/redis database flushed/', $commandTester->getDisplay());
+        $this->assertMatchesRegularExpression('/redis database flushed/', $commandTester->getDisplay());
     }
 
     public function testClientOptionWithNotExistingClient()
@@ -123,7 +123,7 @@ class RedisFlushdbCommandTest extends CommandTestCase
         $commandTester = new CommandTester($command);
         $commandTester->execute(array('command' => $command->getName(), '--client' => 'notExisting', '--no-interaction' => true));
 
-        $this->assertRegExp('/The client "notExisting" is not defined/', $commandTester->getDisplay());
+        $this->assertMatchesRegularExpression('/The client "notExisting" is not defined/', $commandTester->getDisplay());
     }
 
     public function testBugFixInPredis()
@@ -150,7 +150,7 @@ class RedisFlushdbCommandTest extends CommandTestCase
         $commandTester = new CommandTester($command);
         $commandTester->execute(array('command' => $command->getName(), '--no-interaction' => true));
 
-        $this->assertRegExp('/redis database flushed/', $commandTester->getDisplay());
+        $this->assertMatchesRegularExpression('/redis database flushed/', $commandTester->getDisplay());
     }
 
     protected function getCommand()

--- a/Tests/Command/RedisFlushdbCommandTest.php
+++ b/Tests/Command/RedisFlushdbCommandTest.php
@@ -64,7 +64,7 @@ class RedisFlushdbCommandTest extends CommandTestCase
         $commandTester = new CommandTester($command);
         $commandTester->execute(array('command' => $command->getName(), '--no-interaction' => true));
 
-        $this->assertMatchesRegularExpression('/redis database flushed/', $commandTester->getDisplay());
+        $this->assertRegExp('/redis database flushed/', $commandTester->getDisplay());
     }
 
     public function testClientOption()
@@ -104,7 +104,7 @@ class RedisFlushdbCommandTest extends CommandTestCase
         $commandTester = new CommandTester($command);
         $commandTester->execute(array('command' => $command->getName(), '--client' => 'special', '--no-interaction' => true));
 
-        $this->assertMatchesRegularExpression('/redis database flushed/', $commandTester->getDisplay());
+        $this->assertRegExp('/redis database flushed/', $commandTester->getDisplay());
     }
 
     public function testClientOptionWithNotExistingClient()
@@ -123,7 +123,7 @@ class RedisFlushdbCommandTest extends CommandTestCase
         $commandTester = new CommandTester($command);
         $commandTester->execute(array('command' => $command->getName(), '--client' => 'notExisting', '--no-interaction' => true));
 
-        $this->assertMatchesRegularExpression('/The client "notExisting" is not defined/', $commandTester->getDisplay());
+        $this->assertRegExp('/The client "notExisting" is not defined/', $commandTester->getDisplay());
     }
 
     public function testBugFixInPredis()
@@ -150,7 +150,7 @@ class RedisFlushdbCommandTest extends CommandTestCase
         $commandTester = new CommandTester($command);
         $commandTester->execute(array('command' => $command->getName(), '--no-interaction' => true));
 
-        $this->assertMatchesRegularExpression('/redis database flushed/', $commandTester->getDisplay());
+        $this->assertRegExp('/redis database flushed/', $commandTester->getDisplay());
     }
 
     protected function getCommand()

--- a/Tests/DependencyInjection/Compiler/ClientLocatorPassTest.php
+++ b/Tests/DependencyInjection/Compiler/ClientLocatorPassTest.php
@@ -14,12 +14,11 @@ use Symfony\Component\DependencyInjection\ServiceLocator;
 
 class ClientLocatorPassTest extends TestCase
 {
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage no redis clients found (tag name: snc_redis.client)
-     */
     public function testThrowRuntimeExceptionWhenNoRedisClientsExist()
     {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('no redis clients found (tag name: snc_redis.client)');
+
         (new ClientLocatorPass())->process(new ContainerBuilder());
     }
 

--- a/Tests/DependencyInjection/SncRedisExtensionEnvTest.php
+++ b/Tests/DependencyInjection/SncRedisExtensionEnvTest.php
@@ -15,7 +15,7 @@ class SncRedisExtensionEnvTest extends TestCase
     /**
      * @see http://symfony.com/blog/new-in-symfony-3-2-runtime-environment-variables
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         if (version_compare(Kernel::VERSION, '3.2.0', '<')) {
             $this->markTestSkipped(
@@ -42,7 +42,7 @@ class SncRedisExtensionEnvTest extends TestCase
 
         $this->assertSame('Redis', $clientDefinition->getClass());
         $this->assertSame('Redis', $clientDefinition->getArgument(0));
-        $this->assertContains('REDIS_URL', $clientDefinition->getArgument(1)[0]);
+        $this->assertStringContainsString('REDIS_URL', $clientDefinition->getArgument(1)[0]);
         $this->assertSame('default', $clientDefinition->getArgument(3));
 
         $this->assertSame(
@@ -77,7 +77,7 @@ class SncRedisExtensionEnvTest extends TestCase
 
         $this->assertSame($clientClass, $clientDefinition->getClass());
         $this->assertSame($clientClass, $clientDefinition->getArgument(0));
-        $this->assertContains('TEST_URL_2', $clientDefinition->getArgument(1)[0]);
+        $this->assertStringContainsString('TEST_URL_2', $clientDefinition->getArgument(1)[0]);
         $this->assertSame('alias_test', $clientDefinition->getArgument(3));
         $this->assertSame(
             array(
@@ -117,7 +117,7 @@ class SncRedisExtensionEnvTest extends TestCase
         $this->assertEquals('snc_redis.connection.default1_parameters.default', (string) $parameters[0]);
         $this->assertEquals('snc_redis.connection.default2_parameters.default', (string) $parameters[1]);
 
-        $this->assertInternalType('array', $container->findTaggedServiceIds('snc_redis.client'));
+        $this->assertIsArray($container->findTaggedServiceIds('snc_redis.client'));
         $this->assertEquals(['snc_redis.default' => [['alias' => 'default']]], $container->findTaggedServiceIds('snc_redis.client'));
     }
 
@@ -128,7 +128,7 @@ class SncRedisExtensionEnvTest extends TestCase
 
         $this->assertSame('RedisCluster', $clientDefinition->getClass());
         $this->assertSame('RedisCluster', $clientDefinition->getArgument(0));
-        $this->assertContains('REDIS_URL_1', $clientDefinition->getArgument(1)[0]);
+        $this->assertStringContainsString('REDIS_URL_1', $clientDefinition->getArgument(1)[0]);
         $this->assertSame('phprediscluster', $clientDefinition->getArgument(3));
 
         $this->assertSame(
@@ -156,9 +156,9 @@ class SncRedisExtensionEnvTest extends TestCase
 
         $this->assertSame('RedisCluster', $clientDefinition->getClass());
         $this->assertSame('RedisCluster', $clientDefinition->getArgument(0));
-        $this->assertContains('REDIS_URL_1', $clientDefinition->getArgument(1)[0]);
-        $this->assertContains('REDIS_URL_2', $clientDefinition->getArgument(1)[1]);
-        $this->assertContains('REDIS_URL_3', $clientDefinition->getArgument(1)[2]);
+        $this->assertStringContainsString('REDIS_URL_1', $clientDefinition->getArgument(1)[0]);
+        $this->assertStringContainsString('REDIS_URL_2', $clientDefinition->getArgument(1)[1]);
+        $this->assertStringContainsString('REDIS_URL_3', $clientDefinition->getArgument(1)[2]);
         $this->assertSame('phprediscluster', $clientDefinition->getArgument(3));
 
         $this->assertSame(

--- a/Tests/DependencyInjection/SncRedisExtensionTest.php
+++ b/Tests/DependencyInjection/SncRedisExtensionTest.php
@@ -431,12 +431,12 @@ class SncRedisExtensionTest extends TestCase
         $defaultParameters = $container->getDefinition('snc_redis.default');
 
         $this->assertSame(1, $defaultParameters->getArgument(2)['parameters']['database']);
-        $this->assertSame('pass', $defaultParameters->getArgument(2)['parameters']['password']);
+        $this->assertSame('sncredis', $defaultParameters->getArgument(2)['parameters']['password']);
 
         $redis = $container->get('snc_redis.default');
 
         $this->assertSame(1, $redis->getDBNum());
-        $this->assertSame('pass', $redis->getAuth());
+        $this->assertSame('sncredis', $redis->getAuth());
     }
 
     /**
@@ -451,12 +451,12 @@ class SncRedisExtensionTest extends TestCase
         $defaultParameters = $container->getDefinition('snc_redis.default');
 
         $this->assertSame(2, $defaultParameters->getArgument(2)['parameters']['database']);
-        $this->assertSame('word', $defaultParameters->getArgument(2)['parameters']['password']);
+        $this->assertSame('otherpassword', $defaultParameters->getArgument(2)['parameters']['password']);
 
         $redis = $container->get('snc_redis.default');
 
         $this->assertSame(1, $redis->getDBNum());
-        $this->assertSame('pass', $redis->getAuth());
+        $this->assertSame('sncredis', $redis->getAuth());
     }
 
     /**
@@ -759,7 +759,7 @@ clients:
         options:
             parameters:
                 database: 1
-                password: pass
+                password: sncredis
 EOF;
     }
 
@@ -770,11 +770,11 @@ clients:
     default:
         type: phpredis
         alias: default
-        dsn: redis://redis:pass@localhost/1
+        dsn: redis://redis:sncredis@localhost/1
         options:
             parameters:
                 database: 2
-                password: word
+                password: otherpassword
 EOF;
     }
 
@@ -790,7 +790,7 @@ clients:
             cluster: true
 EOF;
     }
-    
+
     private function getContainer()
     {
         return new ContainerBuilder(new ParameterBag(array(

--- a/Tests/DependencyInjection/SncRedisExtensionTest.php
+++ b/Tests/DependencyInjection/SncRedisExtensionTest.php
@@ -14,6 +14,7 @@ namespace Snc\RedisBundle\Tests\DependencyInjection;
 use PHPUnit\Framework\TestCase;
 use Snc\RedisBundle\DependencyInjection\Configuration\Configuration;
 use Snc\RedisBundle\DependencyInjection\SncRedisExtension;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -96,7 +97,7 @@ class SncRedisExtensionTest extends TestCase
         $config = $this->parseYaml($this->getMinimalYamlConfig());
         $extension->load(array($config), $container = $this->getContainer());
 
-        $this->assertInternalType('array', $container->findTaggedServiceIds('snc_redis.client'));
+        $this->assertIsArray($container->findTaggedServiceIds('snc_redis.client'));
         $this->assertCount(1, $container->findTaggedServiceIds('snc_redis.client'), 'Minimal Yaml should have tagged 1 client');
     }
 
@@ -116,7 +117,7 @@ class SncRedisExtensionTest extends TestCase
         $this->assertTrue($container->hasDefinition('snc_redis.client.default_options'));
         $this->assertTrue($container->hasDefinition('snc_redis.default'));
         $this->assertFalse($container->hasAlias('snc_redis.default_client'));
-        $this->assertInternalType('array', $container->findTaggedServiceIds('snc_redis.client'));
+        $this->assertIsArray($container->findTaggedServiceIds('snc_redis.client'));
         $this->assertEquals(array('snc_redis.default' => array(array('alias' => 'default'))), $container->findTaggedServiceIds('snc_redis.client'));
     }
 
@@ -181,7 +182,7 @@ class SncRedisExtensionTest extends TestCase
         $this->assertTrue($container->hasDefinition('snc_redis.swiftmailer.spool'));
         $this->assertTrue($container->hasAlias('swiftmailer.spool.redis'));
 
-        $this->assertInternalType('array', $container->findTaggedServiceIds('snc_redis.client'));
+        $this->assertIsArray($container->findTaggedServiceIds('snc_redis.client'));
         $this->assertGreaterThanOrEqual(4, count($container->findTaggedServiceIds('snc_redis.client')), 'expected at least 4 tagged clients');
 
         $tags = $container->findTaggedServiceIds('snc_redis.client');
@@ -189,27 +190,25 @@ class SncRedisExtensionTest extends TestCase
         $this->assertArrayHasKey('snc_redis.cache', $tags);
         $this->assertArrayHasKey('snc_redis.monolog', $tags);
         $this->assertArrayHasKey('snc_redis.cluster', $tags);
-        $this->assertArraySubset(array('snc_redis.cache' => array(array('alias' => 'cache'))), $tags);
-        $this->assertArraySubset(array('snc_redis.cluster' => array(array('alias' => 'cluster'))), $tags);
+        $this->assertEquals([['alias' => 'cache']], $tags['snc_redis.cache']);
+        $this->assertEquals([['alias' => 'cluster']], $tags['snc_redis.cluster']);
     }
 
-    /**
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     * @expectedExceptionMessage requires it to reference either an entity manager or document manager
-     */
     public function testInvalidDoctrineCacheConfigLoad()
     {
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('requires it to reference either an entity manager or document manager');
+
         $extension = new SncRedisExtension();
         $config = $this->parseYaml($this->getInvalidDoctrineCacheConfig());
         $extension->load(array($config), $this->getContainer());
     }
 
-    /**
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     * @expectedExceptionMessage You have to disable logging for the client
-     */
     public function testInvalidMonologConfigLoad()
     {
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('You have to disable logging for the client');
+
         $extension = new SncRedisExtension();
         $config = $this->parseYaml($this->getInvalidMonologYamlConfig());
         $extension->load(array($config), $this->getContainer());
@@ -292,11 +291,10 @@ class SncRedisExtensionTest extends TestCase
         $loader->load('valid.xml');
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testInvalidXmlConfig()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $container = $this->getContainer();
         $container->registerExtension(new SncRedisExtension());
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__ . '/Fixtures/config/xml'));
@@ -332,7 +330,7 @@ class SncRedisExtensionTest extends TestCase
         $masterParameters = $container->getDefinition((string) $parameters[0])->getArgument(0);
         $this->assertTrue($masterParameters['replication']);
 
-        $this->assertInternalType('array', $container->findTaggedServiceIds('snc_redis.client'));
+        $this->assertIsArray($container->findTaggedServiceIds('snc_redis.client'));
         $this->assertEquals(array('snc_redis.default' => array(array('alias' => 'default'))), $container->findTaggedServiceIds('snc_redis.client'));
     }
 
@@ -367,11 +365,11 @@ class SncRedisExtensionTest extends TestCase
         $masterParameters = $container->getDefinition((string) $parameters[0])->getArgument(0);
         $this->assertEquals('sentinel', $masterParameters['replication']);
         $this->assertEquals('mymaster', $masterParameters['service']);
-        $this->assertInternalType('array', $masterParameters['parameters']);
+        $this->assertIsArray($masterParameters['parameters']);
         $this->assertEquals('1', $masterParameters['parameters']['database']);
         $this->assertEquals('pass', $masterParameters['parameters']['password']);
 
-        $this->assertInternalType('array', $container->findTaggedServiceIds('snc_redis.client'));
+        $this->assertIsArray($container->findTaggedServiceIds('snc_redis.client'));
         $this->assertEquals(array('snc_redis.default' => array(array('alias' => 'default'))), $container->findTaggedServiceIds('snc_redis.client'));
     }
 
@@ -392,11 +390,11 @@ class SncRedisExtensionTest extends TestCase
         $masterParameters = $container->getDefinition((string) $parameters[0])->getArgument(0);
         $this->assertEquals('sentinel', $masterParameters['replication']);
         $this->assertEquals('mymaster', $masterParameters['service']);
-        $this->assertInternalType('array', $masterParameters['parameters']);
+        $this->assertIsArray($masterParameters['parameters']);
         $this->assertEquals('1', $masterParameters['parameters']['database']);
         $this->assertEquals('pass', $masterParameters['parameters']['password']);
 
-        $this->assertInternalType('array', $container->findTaggedServiceIds('snc_redis.client'));
+        $this->assertIsArray($container->findTaggedServiceIds('snc_redis.client'));
         $this->assertEquals(array('snc_redis.default' => array(array('alias' => 'default'))), $container->findTaggedServiceIds('snc_redis.client'));
     }
 
@@ -417,7 +415,7 @@ class SncRedisExtensionTest extends TestCase
         $this->assertEquals('snc_redis.connection.default1_parameters.default', (string) $parameters[0]);
         $this->assertEquals('snc_redis.connection.default2_parameters.default', (string) $parameters[1]);
 
-        $this->assertInternalType('array', $container->findTaggedServiceIds('snc_redis.client'));
+        $this->assertIsArray($container->findTaggedServiceIds('snc_redis.client'));
         $this->assertEquals(array('snc_redis.default' => array(array('alias' => 'default'))), $container->findTaggedServiceIds('snc_redis.client'));
     }
 

--- a/Tests/Extra/RateLimitTest.php
+++ b/Tests/Extra/RateLimitTest.php
@@ -28,7 +28,7 @@ class RateLimitTest extends TestCase
     /**
      * {@inheritdoc}
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $config = 'tcp://127.0.0.1:6379';
 
@@ -56,7 +56,7 @@ class RateLimitTest extends TestCase
     /**
      * {@inheritdoc}
      */
-    protected function tearDown()
+    protected function tearDown(): void
     {
         unset($this->_redis);
     }

--- a/Tests/Factory/PhpredisClientFactoryTest.php
+++ b/Tests/Factory/PhpredisClientFactoryTest.php
@@ -10,7 +10,7 @@ use Snc\RedisBundle\Client\Phpredis\Client;
 
 class PhpredisClientFactoryTest extends TestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         if (!class_exists(\Redis::class)) {
             $this->markTestSkipped(sprintf('The %s requires phpredis extension.', __CLASS__));

--- a/Tests/Factory/PhpredisClientFactoryTest.php
+++ b/Tests/Factory/PhpredisClientFactoryTest.php
@@ -95,7 +95,7 @@ class PhpredisClientFactoryTest extends TestCase
 
         $client = $factory->create(
             \Redis::class,
-            ['redis://redis:pass@localhost:6379/2'],
+            ['redis://redis:sncredis@localhost:6379/2'],
             array(
                 'parameters' => [
                     'database' => 3,
@@ -107,7 +107,7 @@ class PhpredisClientFactoryTest extends TestCase
 
         $this->assertInstanceOf(\Redis::class, $client);
         $this->assertSame(2, $client->getDBNum());
-        $this->assertSame('pass', $client->getAuth());
+        $this->assertSame('sncredis', $client->getAuth());
         $this->assertNull($client->getPersistentID());
     }
 
@@ -117,7 +117,7 @@ class PhpredisClientFactoryTest extends TestCase
 
         $client = $factory->create(
             \Redis::class,
-            [['redis://redis:pass@localhost:6379/2']],
+            [['redis://redis:sncredis@localhost:6379/2']],
             array(
                 'parameters' => [
                     'database' => 3,
@@ -129,7 +129,7 @@ class PhpredisClientFactoryTest extends TestCase
 
         $this->assertInstanceOf(\Redis::class, $client);
         $this->assertSame(2, $client->getDBNum());
-        $this->assertSame('pass', $client->getAuth());
+        $this->assertSame('sncredis', $client->getAuth());
         $this->assertNull($client->getPersistentID());
     }
 }

--- a/Tests/Factory/PredisParametersFactoryTest.php
+++ b/Tests/Factory/PredisParametersFactoryTest.php
@@ -143,11 +143,10 @@ class PredisParametersFactoryTest extends TestCase
         $this->assertObjectNotHasAttribute('user', $parameters);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testCreateException()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         PredisParametersFactory::create(array(), \stdClass::class, 'redis://localhost');
     }
 }

--- a/Tests/Functional/App/config.yaml
+++ b/Tests/Functional/App/config.yaml
@@ -33,20 +33,20 @@ snc_redis:
         default:
             type: phpredis
             alias: default
-            dsn: redis://localhost
+            dsn: redis://redis:sncredis@localhost
             logging: '%kernel.debug%'
         cache:
             type: predis
             alias: cache
-            dsn: redis://localhost/1
+            dsn: redis://redis:sncredis@localhost/1
             logging: false
         cluster:
             type: predis
             alias: cluster
             dsn:
-              - redis://127.0.0.1/3
-              - redis://127.0.0.1/4
-              - redis://127.0.0.1/5
+              - redis://redis:sncredis@127.0.0.1/3
+              - redis://redis:sncredis@127.0.0.1/4
+              - redis://redis:sncredis@127.0.0.1/5
             options:
                 prefix: foo
                 profile: 2.4

--- a/Tests/Functional/IntegrationTest.php
+++ b/Tests/Functional/IntegrationTest.php
@@ -36,7 +36,7 @@ class IntegrationTest extends WebTestCase
     /** @var EntityManagerInterface */
     private $em;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $fs = new Filesystem();
         $fs->remove(__DIR__ .'/App/var');

--- a/Tests/Profiler/Storage/RedisProfilerStorageTest.php
+++ b/Tests/Profiler/Storage/RedisProfilerStorageTest.php
@@ -24,7 +24,7 @@ class RedisProfilerStorageTest extends TestCase
 {
     protected static $storage;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         if (Kernel::VERSION_ID >= 40400) {
             $this->markTestSkipped('Redis profiler storage is not supported since Symfony 4.4');
@@ -41,7 +41,7 @@ class RedisProfilerStorageTest extends TestCase
         }
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         if (self::$storage) {
             self::$storage->purge();
@@ -304,7 +304,7 @@ class RedisProfilerStorageTest extends TestCase
 
         $tokens = $this->getStorage()->find('', '', 10, '');
         $this->assertCount(2, $tokens);
-        $this->assertContains($tokens[0]['status_code'], array(200, 404));
-        $this->assertContains($tokens[1]['status_code'], array(200, 404));
+        $this->assertContains($tokens[0]['status_code'], ['200', '404']);
+        $this->assertContains($tokens[1]['status_code'], ['200', '404']);
     }
 }

--- a/Tests/Session/Storage/Handler/RedisSessionHandlerTest.php
+++ b/Tests/Session/Storage/Handler/RedisSessionHandlerTest.php
@@ -25,7 +25,7 @@ class RedisSessionHandlerTest extends TestCase
     {
         $this->redis = $this
             ->getMockBuilder('Predis\Client')
-            ->setMethods(array('get', 'set', 'setex', 'del'))
+            ->setMethods(array('get', 'set', 'setex', 'del', 'sncFreeSessionLock'))
             ->getMock();
     }
 

--- a/Tests/Session/Storage/Handler/RedisSessionHandlerTest.php
+++ b/Tests/Session/Storage/Handler/RedisSessionHandlerTest.php
@@ -21,7 +21,7 @@ class RedisSessionHandlerTest extends TestCase
 {
     private $redis;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->redis = $this
             ->getMockBuilder('Predis\Client')
@@ -29,7 +29,7 @@ class RedisSessionHandlerTest extends TestCase
             ->getMock();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         unset($this->redis);
     }

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.3 || ^8.0",
+        "php": "^7.2 || ^8.0",
         "symfony/framework-bundle": "^3.4.23 || ^4.2.4 || ^5.0",
         "symfony/http-foundation": "^3.4 || ^4.2 || ^5.0",
         "symfony/yaml": "^3.4 || ^4.2 || ^5.0"
@@ -29,7 +29,7 @@
         "ext-pdo_sqlite": "*",
         "doctrine/doctrine-bundle": "^1.11.2 || ^2.0",
         "doctrine/orm": "^2.6.4",
-        "phpunit/phpunit": "^9.4",
+        "phpunit/phpunit": "^8.5",
         "predis/predis": "^1.1",
         "swiftmailer/swiftmailer": "^6.0",
         "symfony/browser-kit": "^3.4 || ^4.2 || ^5.0",

--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,8 @@
         }
     ],
     "require": {
-        "php": "^7.1.3",
-        "symfony/framework-bundle": "^3.4 || ^4.2 || ^5.0",
+        "php": "^7.3 || ^8.0",
+        "symfony/framework-bundle": "^3.4.23 || ^4.2.4 || ^5.0",
         "symfony/http-foundation": "^3.4 || ^4.2 || ^5.0",
         "symfony/yaml": "^3.4 || ^4.2 || ^5.0"
     },
@@ -29,14 +29,14 @@
         "ext-pdo_sqlite": "*",
         "doctrine/doctrine-bundle": "^1.11.2 || ^2.0",
         "doctrine/orm": "^2.6.4",
-        "phpunit/phpunit": "^7.5",
+        "phpunit/phpunit": "^9.4",
         "predis/predis": "^1.1",
         "swiftmailer/swiftmailer": "^6.0",
         "symfony/browser-kit": "^3.4 || ^4.2 || ^5.0",
         "symfony/console": "^3.4 || ^4.2 || ^5.0",
-        "symfony/phpunit-bridge": "^4.3.5",
         "symfony/dom-crawler": "^3.4 || ^4.2 || ^5.0",
         "symfony/filesystem": "^3.4 || ^4.2 || ^5.0",
+        "symfony/phpunit-bridge": "^4.4.8",
         "symfony/profiler-pack": "^1.0",
         "symfony/swiftmailer-bundle": "^2.0 || ^3.0",
         "symfony/twig-bundle": "^3.4 || ^4.2 || ^5.0"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -20,18 +20,19 @@
         </testsuite>
     </testsuites>
 
-    <logging>
-        <log type="coverage-text"/>
-        <log type="coverage-clover" target="./build/coverage/log/coverage.xml"/>
-    </logging>
+    <logging/>
 
-    <filter>
-        <whitelist>
+    <coverage>
+        <include>
             <directory>./</directory>
-            <exclude>
-                <directory>./Tests</directory>
-                <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+        </include>
+        <exclude>
+            <directory>./Tests</directory>
+            <directory>./vendor</directory>
+        </exclude>
+        <report>
+            <clover outputFile="./build/coverage/log/coverage.xml"/>
+            <text outputFile=""/>
+        </report>
+    </coverage>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -20,19 +20,18 @@
         </testsuite>
     </testsuites>
 
-    <logging/>
+    <logging>
+        <log type="coverage-text"/>
+        <log type="coverage-clover" target="./build/coverage/log/coverage.xml"/>
+    </logging>
 
-    <coverage>
-        <include>
+    <filter>
+        <whitelist>
             <directory>./</directory>
-        </include>
-        <exclude>
-            <directory>./Tests</directory>
-            <directory>./vendor</directory>
-        </exclude>
-        <report>
-            <clover outputFile="./build/coverage/log/coverage.xml"/>
-            <text outputFile=""/>
-        </report>
-    </coverage>
+            <exclude>
+                <directory>./Tests</directory>
+                <directory>./vendor</directory>
+            </exclude>
+        </whitelist>
+    </filter>
 </phpunit>


### PR DESCRIPTION
This includes upgrading to PHPUnit 9 for PHP 8 support. As PHPUnit 9 only supports PHP >= 7.3, support for older PHP versions is dropped as they can no longer be automatically tested against.