### PR TITLE
Add json serialization type for phpredis

### DIFF
--- a/Factory/PhpredisClientFactory.php
+++ b/Factory/PhpredisClientFactory.php
@@ -203,6 +203,10 @@ class PhpredisClientFactory
             $types['igbinary'] = \Redis::SERIALIZER_IGBINARY;
         }
 
+        if (defined('Redis::SERIALIZER_JSON')) {
+            $types['json'] = \Redis::SERIALIZER_JSON;
+        }
+
         if (array_key_exists($type, $types)) {
             return $types[$type];
         }


### PR DESCRIPTION
Adding the json serialization type for php redis.

This type has been added a few years ago with this PR https://github.com/phpredis/phpredis/pull/1552

```
snc_redis:
    clients:
        default:
            type: phpredis
            alias: default
            dsn: "%env(REDIS_URL)%"
            options:
                serialization: json
```