### PR TITLE
RedisProfilerStorage: fix method signatures for Symfony 4.4

### DIFF
--- a/Profiler/Storage/RedisProfilerStorage.php
+++ b/Profiler/Storage/RedisProfilerStorage.php
@@ -74,7 +74,7 @@ class RedisProfilerStorage implements ProfilerStorageInterface
     /**
      * {@inheritdoc}
      */
-    public function find($ip, $url, $limit, $method, $start = null, $end = null)
+    public function find($ip, $url, $limit, $method, $start = null, $end = null): array
     {
         $indexName = $this->getIndexName();
 
@@ -163,7 +163,7 @@ class RedisProfilerStorage implements ProfilerStorageInterface
     /**
      * {@inheritdoc}
      */
-    public function read($token)
+    public function read($token): ?Profile
     {
         if (empty($token)) {
             return false;
@@ -181,7 +181,7 @@ class RedisProfilerStorage implements ProfilerStorageInterface
     /**
      * {@inheritdoc}
      */
-    public function write(Profile $profile)
+    public function write(Profile $profile): bool
     {
         $data = array(
             'token' => $profile->getToken(),


### PR DESCRIPTION
Hello,

When migrating to Symfony 4.4 I had errors regarding the signature of some methods in the `RedisProfilerStorage` class.
This PR simply fixes them, I didn't try to look for other inconsistencies but for now it seems to work.