### PR TITLE
Make param/return types of RedisSessionHandler PHP 8.1 compatible

### DIFF
--- a/Session/Storage/Handler/RedisSessionHandler.php
+++ b/Session/Storage/Handler/RedisSessionHandler.php
@@ -118,6 +118,7 @@ class RedisSessionHandler extends AbstractSessionHandler
     /**
      * @return bool
      */
+    #[\ReturnTypeWillChange]
     public function close()
     {
         if ($this->locking && $this->locked) {
@@ -132,6 +133,7 @@ class RedisSessionHandler extends AbstractSessionHandler
      *
      * @return bool
      */
+    #[\ReturnTypeWillChange]
     public function updateTimestamp($sessionId, $data)
     {
         if (0 < $this->ttl) {
@@ -146,6 +148,7 @@ class RedisSessionHandler extends AbstractSessionHandler
      *
      * @return int|false
      */
+    #[\ReturnTypeWillChange]
     public function gc($maxlifetime)
     {
         // not required here because redis will auto expire the keys as long as ttl is set


### PR DESCRIPTION
Solves these errors on PHP 8.1:
```
Return type of Snc\RedisBundle\Session\Storage\Handler\RedisSessionHandler::close() should either be compatible with SessionHandlerInterface::close(): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice
Return type of Snc\RedisBundle\Session\Storage\Handler\RedisSessionHandler::gc($maxlifetime) should either be compatible with SessionHandlerInterface::gc(int $max_lifetime): int|false, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice
Return type of Snc\RedisBundle\Session\Storage\Handler\RedisSessionHandler::updateTimestamp($sessionId, $data) should either be compatible with SessionUpdateTimestampHandlerInterface::updateTimestamp(string $id, string $data): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice
```