### PR TITLE
Make prefix/suffix interceptors for phpredis logging customizable

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -22,4 +22,9 @@
             <property name="spacing" value="0"/>
         </properties>
     </rule>
+
+    <rule ref="SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing">
+        <!-- Produces "Redis::flushAll(): Argument #1 ($async) must be of type bool, null given". Is fixed in dev version of phpredis -->
+        <exclude-pattern>src/Logger/RedisCallInterceptor.php</exclude-pattern>
+    </rule>
 </ruleset>

--- a/src/DependencyInjection/SncRedisExtension.php
+++ b/src/DependencyInjection/SncRedisExtension.php
@@ -21,6 +21,7 @@ use Snc\RedisBundle\DependencyInjection\Configuration\Configuration;
 use Snc\RedisBundle\DependencyInjection\Configuration\RedisDsn;
 use Snc\RedisBundle\DependencyInjection\Configuration\RedisEnvDsn;
 use Snc\RedisBundle\Factory\PredisParametersFactory;
+use Snc\RedisBundle\Logger\RedisCallInterceptor;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\Config\FileLocator;
@@ -52,11 +53,11 @@ class SncRedisExtension extends Extension
         $phpredisFactoryDefinition = $container->getDefinition('snc_redis.phpredis_factory');
 
         if (!$container->getParameter('kernel.debug')) {
-            $phpredisFactoryDefinition->replaceArgument('$stopwatch', null);
+            $container->getDefinition(RedisCallInterceptor::class)->replaceArgument(1, null);
         }
 
         if (!class_exists(\ProxyManager\Configuration::class)) {
-            $phpredisFactoryDefinition->replaceArgument('$proxyConfiguration', null);
+            $phpredisFactoryDefinition->replaceArgument(1, null);
         }
 
         foreach ($config['class'] as $name => $class) {

--- a/tests/Factory/PhpredisClientFactoryTest.php
+++ b/tests/Factory/PhpredisClientFactoryTest.php
@@ -10,6 +10,7 @@ use Psr\Log\LoggerInterface;
 use Redis;
 use RedisCluster;
 use Snc\RedisBundle\Factory\PhpredisClientFactory;
+use Snc\RedisBundle\Logger\RedisCallInterceptor;
 use Snc\RedisBundle\Logger\RedisLogger;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 
@@ -37,7 +38,7 @@ class PhpredisClientFactoryTest extends TestCase
     public function testCreateMinimalConfig(): void
     {
         $this->logger->expects($this->never())->method('debug');
-        $factory = new PhpredisClientFactory($this->redisLogger);
+        $factory = new PhpredisClientFactory(new RedisCallInterceptor($this->redisLogger));
 
         $client = $factory->create(Redis::class, ['redis://localhost:6379'], ['connection_timeout' => 5], 'default', false);
 
@@ -52,7 +53,7 @@ class PhpredisClientFactoryTest extends TestCase
     public function testUnixDsnConfig(): void
     {
         $this->expectExceptionMessage('php_network_getaddresses');
-        (new PhpredisClientFactory($this->redisLogger))
+        (new PhpredisClientFactory(new RedisCallInterceptor($this->redisLogger)))
             ->create(
                 Redis::class,
                 ['redis:///run/redis/redis.sock'],
@@ -65,7 +66,7 @@ class PhpredisClientFactoryTest extends TestCase
     public function testCreateMinimalClusterConfig(): void
     {
         $this->logger->expects($this->never())->method('debug');
-        $factory = new PhpredisClientFactory($this->redisLogger);
+        $factory = new PhpredisClientFactory(new RedisCallInterceptor($this->redisLogger));
 
         $client = $factory->create(
             RedisCluster::class,
@@ -85,7 +86,7 @@ class PhpredisClientFactoryTest extends TestCase
 
     public function testCreateFullConfig(): void
     {
-        $factory = new PhpredisClientFactory($this->redisLogger);
+        $factory = new PhpredisClientFactory(new RedisCallInterceptor($this->redisLogger));
 
         $client = $factory->create(
             Redis::class,
@@ -123,7 +124,7 @@ class PhpredisClientFactoryTest extends TestCase
             ['Executing command "SELECT 2"']
         );
 
-        $factory = new PhpredisClientFactory($this->redisLogger);
+        $factory = new PhpredisClientFactory(new RedisCallInterceptor($this->redisLogger));
 
         $client = $factory->create(
             Redis::class,
@@ -147,7 +148,7 @@ class PhpredisClientFactoryTest extends TestCase
 
     public function testNestedDsnConfig(): void
     {
-        $factory = new PhpredisClientFactory($this->redisLogger);
+        $factory = new PhpredisClientFactory(new RedisCallInterceptor($this->redisLogger));
 
         $client = $factory->create(
             Redis::class,
@@ -172,7 +173,7 @@ class PhpredisClientFactoryTest extends TestCase
     /** @dataProvider serializationTypes */
     public function testLoadSerializationType(string $serializationType, int $serializer): void
     {
-        $factory = new PhpredisClientFactory($this->redisLogger);
+        $factory = new PhpredisClientFactory(new RedisCallInterceptor($this->redisLogger));
 
         $client = $factory->create(
             Redis::class,
@@ -190,7 +191,7 @@ class PhpredisClientFactoryTest extends TestCase
 
     public function testLoadSerializationTypeFail(): void
     {
-        $factory = new PhpredisClientFactory($this->redisLogger);
+        $factory = new PhpredisClientFactory(new RedisCallInterceptor($this->redisLogger));
         $this->expectException(InvalidConfigurationException::class);
 
         $factory->create(

--- a/tests/Functional/IntegrationTest.php
+++ b/tests/Functional/IntegrationTest.php
@@ -28,6 +28,11 @@ class IntegrationTest extends WebTestCase
 {
     private ?KernelBrowser $client = null;
 
+    /**
+     * Muted deprecation "Passing null to parameter #1 ($async) of type bool is deprecated" - would be fixed by next phpredis release with fixed reflection on its own
+     *
+     * @group legacy
+     */
     protected function setUp(): void
     {
         $fs = new Filesystem();


### PR DESCRIPTION
By inversing dependency for prefix/suffix closures and unifying it into something that looks more like an middleware, we are making interceptor customizable. One use case I can think of is building interceptor for APM agents - this way, we don't have to integrate such support inside this bundle, but 3rd party package can be created to facilitate such use cases.