### PR TITLE
Register Alias with an Argument for autowiring.

### DIFF
--- a/src/DependencyInjection/SncRedisExtension.php
+++ b/src/DependencyInjection/SncRedisExtension.php
@@ -198,6 +198,7 @@ class SncRedisExtension extends Extension
 
         $clientDef->addArgument(new Reference($optionId));
         $container->setDefinition(sprintf('snc_redis.%s', $client['alias']), $clientDef);
+        $container->registerAliasForArgument(sprintf('snc_redis.%s', $client['alias']), $clientDef->getClass(),  $client['alias']);
     }
 
     /**
@@ -241,6 +242,7 @@ class SncRedisExtension extends Extension
         $phpredisDef->setLazy(true);
 
         $container->setDefinition(sprintf('snc_redis.%s', $options['alias']), $phpredisDef);
+        $container->registerAliasForArgument(sprintf('snc_redis.%s', $options['alias']), $phpredisClientClass, $options['alias']);
     }
 
     /** @param mixed[] $config */


### PR DESCRIPTION
Allows auto-wiring of clients configured using this bundle via a named argument and the underlying type for that specific client.

See: https://symfony.com/doc/current/service_container.html#binding-arguments-by-name-or-type.

With a bundle configuration of:

``` yaml
snc_redis:
    clients:
        default:
            type: predis
            alias: default
            dsn: "%env(string:REDIS_URL)%"
```

You can autowire via:

```  php
public function __construct(Predis\Client $default) {
    ...
}
```