### PR TITLE
Add redis ACL support for phpredis

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -54,6 +54,15 @@ jobs:
           master1-port: 7000
           master2-port: 7001
           master3-port: 7002
+      - name: "Setup redis with ACL"
+        uses: shogo82148/actions-setup-redis@v1
+        with:
+          redis-version: "6.2"
+          redis-port: "8000"
+          auto-start: "true"
+          redis-conf: |
+            user default on -@all ~* >ARandomPassword
+            user snc_redis on +@all ~* >snc_password
       - name: "Install redis"
         run: |
           sudo apt-get update

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /composer.phar
 /.phpunit.result.cache
 /vendor/
+/.phpcs-cache

--- a/composer.json
+++ b/composer.json
@@ -77,5 +77,8 @@
         "psr-4": {
             "Snc\\RedisBundle\\Tests\\": "tests/"
         }
+    },
+    "scripts": {
+        "test": "@php ./vendor/bin/phpunit"
     }
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -149,6 +149,26 @@ snc_redis:
                 cluster: true
 ```
 
+#### Authentication using Redis ACL
+
+Starting with redis 6.0, it is possible to use an [ACL](https://redis.io/docs/manual/security/acl/) system that only allows users with valid username and password to log in.
+Using the `phpredis` driver, you can set up an authenticated connection like this:
+
+``` yaml
+snc_redis:
+    clients:
+        default:
+            type: phpredis
+            alias: default
+            dsn: redis://localhost
+            # dsn: redis://my_username:my_password@localhost <- username and password can be also set here
+            options:
+                parameters:
+                    username: my_userame
+                    password: my_password
+                
+```
+
 
 ### Sessions ###
 

--- a/src/DependencyInjection/Configuration/Configuration.php
+++ b/src/DependencyInjection/Configuration/Configuration.php
@@ -133,6 +133,7 @@ class Configuration implements ConfigurationInterface
                                         ->canBeUnset()
                                         ->children()
                                             ->scalarNode('database')->defaultNull()->end()
+                                            ->scalarNode('username')->defaultNull()->end()
                                             ->scalarNode('password')->defaultNull()->end()
                                             ->booleanNode('logging')->defaultValue($this->debug)->end()
                                         ->end()

--- a/src/DependencyInjection/Configuration/RedisDsn.php
+++ b/src/DependencyInjection/Configuration/RedisDsn.php
@@ -30,6 +30,8 @@ class RedisDsn
 {
     protected string $dsn;
 
+    protected ?string $username = null;
+
     protected ?string $password = null;
 
     protected ?string $host = null;
@@ -68,6 +70,11 @@ class RedisDsn
     public function getHost(): ?string
     {
         return $this->host;
+    }
+
+    public function getUsername(): ?string
+    {
+        return $this->username;
     }
 
     public function getPassword(): ?string
@@ -123,13 +130,15 @@ class RedisDsn
         $dsn = preg_replace('#rediss?://#', '', $dsn); // remove "redis://" and "rediss://"
         $pos = strrpos($dsn, '@');
         if ($pos !== false) {
-            // parse password
+            // parse username and password
+            $username = null;
             $password = substr($dsn, 0, $pos);
 
             if (strstr($password, ':')) {
-                [, $password] = explode(':', $password, 2);
+                [$username, $password] = explode(':', $password, 2);
             }
 
+            $this->username = $username !== null ? urldecode($username) : null;
             $this->password = urldecode($password);
 
             $dsn = substr($dsn, $pos + 1);

--- a/src/Factory/PhpredisClientFactory.php
+++ b/src/Factory/PhpredisClientFactory.php
@@ -146,8 +146,11 @@ class PhpredisClientFactory
             $client->connect(...$connectParameters);
         }
 
+        $username = $options['parameters']['username'] ?? null;
         $password = $dsn->getPassword() ?? $options['parameters']['password'] ?? null;
-        if ($password) {
+        if ($username !== null && $password !== null) {
+            $client->auth([$username, $password]);
+        } elseif ($password !== null) {
             $client->auth($password);
         }
 

--- a/tests/Command/RedisQueryCommandTest.php
+++ b/tests/Command/RedisQueryCommandTest.php
@@ -14,8 +14,8 @@ declare(strict_types=1);
 namespace Snc\RedisBundle\Tests\Command;
 
 use ArrayIterator;
-use Monolog\Test\TestCase;
 use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
 use Predis\Client;
 use Snc\RedisBundle\Command\RedisQueryCommand;
 use Symfony\Component\Console\Tester\CommandTester;

--- a/tests/DependencyInjection/Configuration/RedisDsnTest.php
+++ b/tests/DependencyInjection/Configuration/RedisDsnTest.php
@@ -202,37 +202,38 @@ class RedisDsnTest extends TestCase
     }
 
     /** @return array<array{0: string, 1: ?string}> */
-    public static function passwordValues(): array
+    public static function authenticationParametersValues(): array
     {
         return [
-            ['redis://localhost', null],
-            ['redis://localhost/1', null],
-            ['redis://pw@localhost:63790/10', 'pw'],
-            ['redis://user:pw@localhost:63790/10', 'pw'],
-            ['redis://user:pw:withcolon@localhost:63790/10', 'pw:withcolon'],
-            ['redis://Pw%3AColon%25@localhost:63790/10', 'Pw:Colon%'],
-            ['redis://p%40w@localhost:63790/10', 'p@w'],
-            ['redis://mB(.z9},6o?zl>v!LM76A]lCg77,;.@localhost:63790/10', 'mB(.z9},6o?zl>v!LM76A]lCg77,;.'],
-            ['redis://127.0.0.1', null],
-            ['redis://127.0.0.1/1', null],
-            ['redis://pw@127.0.0.1:63790/10', 'pw'],
-            ['redis://p%40w@127.0.0.1:63790/10', 'p@w'],
-            ['redis://mB(.z9},6o?zl>v!LM76A]lCg77,;.@127.0.0.1:63790/10', 'mB(.z9},6o?zl>v!LM76A]lCg77,;.'],
-            ['redis://%redis_host%', null],
-            ['redis://%redis_host%/%redis_db%', null],
-            ['redis://%redis_pass%@%redis_host%:%redis_port%', '%redis_pass%'],
-            ['redis:///redis.sock', null],
-            ['redis:///redis.sock/1', null],
-            ['redis://pw@/redis.sock/10', 'pw'],
-            ['redis://p%40w@/redis.sock/10', 'p@w'],
-            ['redis://mB(.z9},6o?zl>v!LM76A]lCg77,;.@/redis.sock/10', 'mB(.z9},6o?zl>v!LM76A]lCg77,;.'],
+            ['redis://localhost', null, null],
+            ['redis://localhost/1', null, null],
+            ['redis://pw@localhost:63790/10', null, 'pw'],
+            ['redis://user:pw@localhost:63790/10', 'user', 'pw'],
+            ['redis://user:pw:withcolon@localhost:63790/10', 'user', 'pw:withcolon'],
+            ['redis://Pw%3AColon%25@localhost:63790/10', null, 'Pw:Colon%'],
+            ['redis://p%40w@localhost:63790/10', null, 'p@w'],
+            ['redis://mB(.z9},6o?zl>v!LM76A]lCg77,;.@localhost:63790/10', null, 'mB(.z9},6o?zl>v!LM76A]lCg77,;.'],
+            ['redis://127.0.0.1', null, null],
+            ['redis://127.0.0.1/1', null, null],
+            ['redis://pw@127.0.0.1:63790/10', null, 'pw'],
+            ['redis://p%40w@127.0.0.1:63790/10', null, 'p@w'],
+            ['redis://mB(.z9},6o?zl>v!LM76A]lCg77,;.@127.0.0.1:63790/10', null, 'mB(.z9},6o?zl>v!LM76A]lCg77,;.'],
+            ['redis://%redis_host%', null, null],
+            ['redis://%redis_host%/%redis_db%', null, null],
+            ['redis://%redis_pass%@%redis_host%:%redis_port%', null, '%redis_pass%'],
+            ['redis:///redis.sock', null, null],
+            ['redis:///redis.sock/1', null, null],
+            ['redis://pw@/redis.sock/10', null, 'pw'],
+            ['redis://p%40w@/redis.sock/10', null, 'p@w'],
+            ['redis://mB(.z9},6o?zl>v!LM76A]lCg77,;.@/redis.sock/10', null, 'mB(.z9},6o?zl>v!LM76A]lCg77,;.'],
         ];
     }
 
-    /** @dataProvider passwordValues */
-    public function testPassword(string $dsn, ?string $password): void
+    /** @dataProvider authenticationParametersValues */
+    public function testAuthenticationParameters(string $dsn, ?string $username, ?string $password): void
     {
         $dsn = new RedisDsn($dsn);
+        $this->assertSame($username, $dsn->getUsername());
         $this->assertSame($password, $dsn->getPassword());
     }
 

--- a/tests/DependencyInjection/Fixtures/config/yaml/env_phpredis_with_acl.yaml
+++ b/tests/DependencyInjection/Fixtures/config/yaml/env_phpredis_with_acl.yaml
@@ -1,0 +1,16 @@
+parameters:
+    env(TEST_URL_2): redis://whatever-host
+
+snc_redis:
+    clients:
+        acl_client:
+            type: phpredis
+            dsn: '%env(TEST_URL_2)%'
+            logging: true
+            options:
+                connection_timeout: 10
+                connection_persistent: true
+                parameters:
+                    username: snc_user
+                    password: snc_password
+                serialization: php

--- a/tests/DependencyInjection/SncRedisExtensionEnvTest.php
+++ b/tests/DependencyInjection/SncRedisExtensionEnvTest.php
@@ -85,6 +85,41 @@ class SncRedisExtensionEnvTest extends TestCase
         $this->assertTrue($clientDefinition->getArgument(4));
     }
 
+    public function testPhpredisWithAclConfig(): void
+    {
+        $container = $this->getConfiguredContainer('env_phpredis_with_acl');
+
+        $clientDefinition = $container->findDefinition('snc_redis.acl_client');
+
+        $this->assertSame('Redis', $clientDefinition->getClass());
+        $this->assertSame('Redis', $clientDefinition->getArgument(0));
+        $this->assertStringContainsString('TEST_URL_2', $clientDefinition->getArgument(1)[0]);
+        $this->assertSame('acl_client', $clientDefinition->getArgument(3));
+
+        $this->assertEquals(
+            [
+                'cluster' => null,
+                'connection_async' => false,
+                'connection_persistent' => true,
+                'connection_timeout' => 10,
+                'iterable_multibulk' => false,
+                'parameters' => [
+                    'username' => 'snc_user',
+                    'password' => 'snc_password',
+                    'database' => null,
+                    'logging' => false,
+                ],
+                'prefix' => null,
+                'profile' => 'default',
+                'read_write_timeout' => null,
+                'serialization' => 'php',
+                'service' => null,
+                'throw_errors' => true,
+            ],
+            $clientDefinition->getArgument(2)
+        );
+    }
+
     public function testProfileOption(): void
     {
         $container = $this->getConfiguredContainer('env_predis_profile');

--- a/tests/Functional/App/config.yaml
+++ b/tests/Functional/App/config.yaml
@@ -40,6 +40,15 @@ snc_redis:
                 read_write_timeout: 30
                 iterable_multibulk: false
                 throw_errors: true
+        with_acl:
+            type: predis
+            alias: with_acl
+            dsn: redis://localhost/1
+            logging: false
+            options:
+                parameters:
+                    username: my_user
+                    password: sncredis
 
 services:
     _defaults:


### PR DESCRIPTION
Starting with Redis 6.0 it's possible to authenticate using username and password on a server with ACL enabled.
In this PR I'm adding the support for `phpredis` driver.

Related to issue #657 