### PR TITLE
#661: avoid sending non-utf8 data to Symfony Stopwatch

### DIFF
--- a/src/Client/Predis/Connection/ConnectionWrapper.php
+++ b/src/Client/Predis/Connection/ConnectionWrapper.php
@@ -157,7 +157,7 @@ class ConnectionWrapper implements NodeConnectionInterface
         $commandName = $this->commandToString($command);
 
         if ($this->stopwatch) {
-            $event = $this->stopwatch->start($commandName, 'redis');
+            $event = $this->stopwatch->start(preg_replace('/[^[:print:]]/', '', $commandName), 'redis');
         }
 
         $startTime = microtime(true);

--- a/src/Client/Predis/Connection/ConnectionWrapper.php
+++ b/src/Client/Predis/Connection/ConnectionWrapper.php
@@ -25,6 +25,7 @@ use function array_reduce;
 use function assert;
 use function is_string;
 use function microtime;
+use function preg_replace;
 use function strlen;
 use function substr;
 use function var_export;


### PR DESCRIPTION
This patches the ConnectionWrapper in the same manner than the first patch in #662 .