### PR TITLE
Reset the logger after the collector reset

### DIFF
--- a/src/DataCollector/RedisDataCollector.php
+++ b/src/DataCollector/RedisDataCollector.php
@@ -35,6 +35,9 @@ class RedisDataCollector extends DataCollector
     public function reset(): void
     {
         $this->data = [];
+        if ($this->logger instanceof ResetInterface) {
+            $this->logger->reset();
+        }
     }
 
     /** @return array{cmd: string, executionMS: float, conn: string, error: string|false} */


### PR DESCRIPTION
\Snc\RedisBundle\Logger\RedisLogger is not implement ResetInterface now, so in some special runtime (like swoole), RedisDataCollector will not destroy previous request's redis command logs. It is better to reset the logger at the time of the collector reset, then developer can decorate the \Snc\RedisBundle\Logger\RedisLogger and reset it.