### PR TITLE
Fix config for replicated setups

### DIFF
--- a/src/DependencyInjection/SncRedisExtension.php
+++ b/src/DependencyInjection/SncRedisExtension.php
@@ -190,7 +190,7 @@ class SncRedisExtension extends Extension
         $container->setDefinition($optionId, $optionDef);
         $clientDef = new Definition((string) $container->getParameter('snc_redis.client.class'));
         $clientDef->addTag('snc_redis.client', ['alias' => $client['alias']]);
-        if ($connectionCount === 1 && !isset($client['options']['cluster'], $client['options']['replication'])) {
+        if ($connectionCount === 1 && !isset($client['options']['cluster']) && !isset($client['options']['replication'])) {
             $clientDef->addArgument(new Reference(sprintf('snc_redis.connection.%s_parameters.%s', $connectionAliases[0], $client['alias'])));
         } else {
             $connections = [];

--- a/tests/DependencyInjection/SncRedisExtensionTest.php
+++ b/tests/DependencyInjection/SncRedisExtensionTest.php
@@ -338,8 +338,8 @@ class SncRedisExtensionTest extends TestCase
         $this->assertEquals('sentinel', $options['replication']);
         $this->assertEquals('mymaster', $options['service']);
         $parameters = $container->getDefinition('snc_redis.default')->getArgument(0);
-        $this->assertEquals('snc_redis.connection.default_parameters.default', (string) $parameters);
-        $masterParameters = $container->getDefinition((string) $parameters)->getArgument(0);
+        $this->assertEquals('snc_redis.connection.default_parameters.default', (string) $parameters[0]);
+        $masterParameters = $container->getDefinition((string) $parameters[0])->getArgument(0);
         $this->assertEquals('sentinel', $masterParameters['replication']);
         $this->assertEquals('mymaster', $masterParameters['service']);
         $this->assertIsArray($masterParameters['parameters']);


### PR DESCRIPTION
There seems to be a bug with replicated setups in v4.4.1, introduced in https://github.com/snc/SncRedisBundle/commit/9e6b11167fc476287ed1cf4768371ff4487738ef .

I'm not sure what the original problem was, but this broke my setup. The problem is that Predis ignores the `replication` option if `$parameters` is not an array: https://github.com/predis/predis/blob/dc14604f3e17bb5c725b8e52c0e55f0ee25320fa/src/Client.php#L113-L139

My config:

```yaml
snc_redis:
  clients:
    default:
      dsn: '%env(REDIS_DSN)%'
      options:
        replication: sentinel
        service: mymaster
```

```sh
REDIS_DSN=redis://redis.redis.svc.cluster.local:26379
```

Before the commit:

![image](https://user-images.githubusercontent.com/2445045/207612660-b11fdf85-dbfa-417d-85af-2206ce540aa5.png)

After the commit:

![image](https://user-images.githubusercontent.com/2445045/207612207-e67afeec-e0c2-4d2f-87cd-42578afa0c8d.png)
