### PR TITLE
Support injecting additional options for php/relay sentinel

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "doctrine/coding-standard": "^10.0",
         "friendsofphp/proxy-manager-lts": "^1.0.6",
         "monolog/monolog": "*",
-        "phpunit/phpunit": "^8.5 || ^9.5",
+        "phpunit/phpunit": "^8.5.32 || ^9.5.28",
         "predis/predis": "^2.0",
         "symfony/browser-kit": "^4.4 || ^5.3 || ^6.0",
         "symfony/cache": "^4.4 || ^5.3 || ^6.0",

--- a/tests/Factory/PhpredisClientFactoryTest.php
+++ b/tests/Factory/PhpredisClientFactoryTest.php
@@ -115,8 +115,15 @@ class PhpredisClientFactoryTest extends TestCase
 
         $client = $factory->create(
             $sentinelClass,
-            ['redis://sncredis@localhost:26379'],
-            ['connection_timeout' => 5, 'connection_persistent' => false, 'service' => 'mymaster'],
+            [
+                'redis://undefined@localhost:55555', // unreachable instance
+                'redis://sncredis@localhost:26379',
+            ],
+            [
+                'connection_timeout' => 5,
+                'connection_persistent' => false,
+                'service' => 'mymaster',
+            ],
             'phpredissentinel',
             true,
         );
@@ -124,6 +131,7 @@ class PhpredisClientFactoryTest extends TestCase
         $this->assertInstanceOf($outputClass, $client);
         $this->assertNull($client->getOption(Redis::OPT_PREFIX));
         $this->assertSame(0, $client->getOption(Redis::OPT_SERIALIZER));
+        $this->assertSame(5., $client->getTimeout());
         $this->assertSame('sncredis', $client->getAuth());
     }
 


### PR DESCRIPTION
- Check next dsn in case of connection failure (RedisException or Relay\Exception thrown)
- Ability to apply `connection_timeout`, `connection_persistent` and `read_write_timeout` configs to sentinel instance
- Fix failed build caused by phpunit on dependency-versions: "lowest" for PHP 7.4 - https://github.com/sebastianbergmann/phpunit/issues/4692