### PR TITLE
Fix installing symfony versions in CI

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -47,9 +47,12 @@ jobs:
           php-version: "${{ matrix.php-version }}"
           extensions: "${{ matrix.php-extensions }},relay"
           ini-values: "zend.assertions=1, max_execution_time=30"
+          tools: "flex"
 
-      - name: "Install symfony/flex"
-        run: "composer require --no-progress --no-scripts --no-plugins symfony/flex"
+      - name: "Remove psalm for Symfony 4.4"
+        if: "${{ matrix.symfony-require == '4.4.*' }}"
+        run: |
+          composer remove --no-update --dev vimeo/psalm
 
       - name: "Install dependencies with Composer"
         uses: "ramsey/composer-install@v2"

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
     "homepage": "https://github.com/snc/SncRedisBundle",
     "license": "MIT",
     "minimum-stability": "dev",
+    "prefer-stable": true,
     "authors": [
         {
             "name": "Henrik Westphal",

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,6 @@
     "homepage": "https://github.com/snc/SncRedisBundle",
     "license": "MIT",
     "minimum-stability": "dev",
-    "prefer-stable": true,
     "authors": [
         {
             "name": "Henrik Westphal",


### PR DESCRIPTION
I've seen the new release and I was checking the versions installed and for example for:
- 4.4: https://github.com/snc/SncRedisBundle/actions/runs/6712763541/job/18243020072
- 5.4: https://github.com/snc/SncRedisBundle/actions/runs/6712763541/job/18243020270

It's installing the packages in the flex step and using incorrect versions.

I've removed `psalm/vimeo` in the job when the using Symfony 4.4 because [it requires `"symfony/filesystem": "^5.4 || ^6.0",`](https://github.com/vimeo/psalm/blob/4e177bf0c9f03c17d2fbfd83b7cc9c47605274d8/composer.json#L38).

I've added the "prefer-stable" section since it was installing dev versions for stable ones (4.4 and 5.4).