### PR TITLE
[fix] Pass on username parameter from dsn to Predis Factory

### DIFF
--- a/src/Factory/PredisParametersFactory.php
+++ b/src/Factory/PredisParametersFactory.php
@@ -58,6 +58,7 @@ class PredisParametersFactory
         if ($dsn->getUsername() !== null) {
             $options['username'] = $dsn->getUsername();
         }
+
         if ($dsn->getDatabase() !== null) {
             $options['database'] = $dsn->getDatabase();
         }

--- a/src/Factory/PredisParametersFactory.php
+++ b/src/Factory/PredisParametersFactory.php
@@ -58,7 +58,6 @@ class PredisParametersFactory
         if ($dsn->getUsername() !== null) {
             $options['username'] = $dsn->getUsername();
         }
-        
         if ($dsn->getDatabase() !== null) {
             $options['database'] = $dsn->getDatabase();
         }

--- a/src/Factory/PredisParametersFactory.php
+++ b/src/Factory/PredisParametersFactory.php
@@ -55,6 +55,10 @@ class PredisParametersFactory
             }
         }
 
+        if ($dsn->getUsername() !== null) {
+            $options['username'] = $dsn->getUsername();
+        }
+        
         if ($dsn->getDatabase() !== null) {
             $options['database'] = $dsn->getDatabase();
         }


### PR DESCRIPTION
After debugging why I could use my application with default credentials, but not with a newly created acl user, I found that the username parameter is not passed in the PredisParametersFactory, when it is defined in the Dsn.

This PR fixes the issue.