### PR TITLE
Remove deprecated usage of Symfony\Component\HttpKernel\DependencyInjection\Extension

### DIFF
--- a/src/DependencyInjection/SncRedisExtension.php
+++ b/src/DependencyInjection/SncRedisExtension.php
@@ -29,7 +29,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 
 use function array_map;
 use function assert;

--- a/src/DependencyInjection/SncRedisExtension.php
+++ b/src/DependencyInjection/SncRedisExtension.php
@@ -27,9 +27,9 @@ use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
-use Symfony\Component\DependencyInjection\Extension\Extension;
 
 use function array_map;
 use function assert;


### PR DESCRIPTION
[Issue](https://github.com/snc/SncRedisBundle/issues/724)