### PR TITLE
Add authentication with username and password for phpredis RedisCluster

### DIFF
--- a/.github/workflows/redis-configs/redis-node1/redis.conf
+++ b/.github/workflows/redis-configs/redis-node1/redis.conf
@@ -5,3 +5,4 @@ appendonly no
 save ""
 bind 0.0.0.0
 protected-mode no
+user snc_redis on +@all ~* >snc_password

--- a/.github/workflows/redis-configs/redis-node2/redis.conf
+++ b/.github/workflows/redis-configs/redis-node2/redis.conf
@@ -5,3 +5,4 @@ appendonly no
 save ""
 bind 0.0.0.0
 protected-mode no
+user snc_redis on +@all ~* >snc_password

--- a/.github/workflows/redis-configs/redis-node3/redis.conf
+++ b/.github/workflows/redis-configs/redis-node3/redis.conf
@@ -5,3 +5,4 @@ appendonly no
 save ""
 bind 0.0.0.0
 protected-mode no
+user snc_redis on +@all ~* >snc_password

--- a/.github/workflows/redis-configs/redis-node4/redis.conf
+++ b/.github/workflows/redis-configs/redis-node4/redis.conf
@@ -5,3 +5,4 @@ appendonly no
 save ""
 bind 0.0.0.0
 protected-mode no
+user snc_redis on +@all ~* >snc_password

--- a/.github/workflows/redis-configs/redis-node5/redis.conf
+++ b/.github/workflows/redis-configs/redis-node5/redis.conf
@@ -5,3 +5,4 @@ appendonly no
 save ""
 bind 0.0.0.0
 protected-mode no
+user snc_redis on +@all ~* >snc_password

--- a/.github/workflows/redis-configs/redis-node6/redis.conf
+++ b/.github/workflows/redis-configs/redis-node6/redis.conf
@@ -5,3 +5,4 @@ appendonly no
 save ""
 bind 0.0.0.0
 protected-mode no
+user snc_redis on +@all ~* >snc_password

--- a/docs/README.md
+++ b/docs/README.md
@@ -169,6 +169,7 @@ snc_redis:
                 
 ```
 
+It also works for the Phpredis Cluster mode.
 
 ### Sessions ###
 

--- a/tests/Factory/PhpredisClientFactoryTest.php
+++ b/tests/Factory/PhpredisClientFactoryTest.php
@@ -105,6 +105,34 @@ class PhpredisClientFactoryTest extends TestCase
         $this->assertSame(0, $client->getOption(RedisCluster::OPT_SLAVE_FAILOVER));
     }
 
+    public function testCreateMinimalClusterConfigWithAcl(): void
+    {
+        $this->logger->expects($this->never())->method('debug');
+        $factory = new PhpredisClientFactory(new RedisCallInterceptor($this->redisLogger));
+
+        $client = $factory->create(
+            RedisCluster::class,
+            ['redis://localhost:7079'],
+            [
+                'connection_timeout' => 5,
+                'connection_persistent' => false,
+                'parameters' => [
+                    'username' => 'snc_redis',
+                    'password' => 'snc_password',
+                ],
+            ],
+            'phprediscluster',
+            false,
+        );
+
+        $this->assertInstanceOf(RedisCluster::class, $client);
+        $this->assertNull($client->getOption(Redis::OPT_PREFIX));
+        $this->assertSame(0, $client->getOption(Redis::OPT_SERIALIZER));
+        $this->assertSame(0., $client->getOption(Redis::OPT_READ_TIMEOUT));
+        $this->assertSame(0, $client->getOption(Redis::OPT_SCAN));
+        $this->assertSame(0, $client->getOption(RedisCluster::OPT_SLAVE_FAILOVER));
+    }
+
     /**
      * @requires extension relay
      * @testWith ["RedisSentinel", "Redis", null, "sentinelauthdefaultpw"]


### PR DESCRIPTION
# Title:
Add authentication with username and password for phpredis RedisCluster

## Description:
This pull request adds support for authentication with a username and password for `RedisCluster` in phpredis. This allows the use of ACLs (Access Control Lists) as specified in the [documentation.](https://github.com/snc/SncRedisBundle/tree/master/docs#authentication-using-redis-acl)

## Changes:
- Updated `PhpredisClientFactory.php` to support authentication for `RedisCluster` with username and password.

---

Please review the changes and provide feedback. Thank you!