### PR TITLE
[Dependency] Added conflict with predis >= 3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -64,7 +64,7 @@
     },
     "conflict": {
         "ext-redis": "<5.3.2",
-        "predis/predis": "<2.0"
+        "predis/predis": "<2.0 || >=3.0"
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
As of today, redis-bundle doesn't implements the latest predis interface. The suggested update will prevent installing/updating this version.

This would fix issue #735 until #736 gets finalized/merged.
