### PR TITLE
feat(composer): add validate strict changes for composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,6 @@
     ],
     "homepage": "https://github.com/snc/SncRedisBundle",
     "license": "MIT",
-    "minimum-stability": "dev",
     "authors": [
         {
             "name": "Henrik Westphal",
@@ -23,10 +22,10 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "symfony/deprecation-contracts": "^2 || ^3",
-        "symfony/framework-bundle": "^5.4.20 ||^6.0 || ^7.0",
-        "symfony/http-foundation": "^5.4.20 ||^6.0 || ^7.0",
-        "symfony/service-contracts": ">=1.0",
-        "symfony/var-dumper": "^5.4.20 ||^6.0 || ^7.0"
+        "symfony/framework-bundle": "^5.4.20 || ^6.0 || ^7.0",
+        "symfony/http-foundation": "^5.4.20 || ^6.0 || ^7.0",
+        "symfony/service-contracts": "^1.0 || ^2.0 || ^3.0",
+        "symfony/var-dumper": "^5.4.20 || ^6.0 || ^7.0"
     },
     "require-dev": {
         "ext-pdo_sqlite": "*",
@@ -36,19 +35,19 @@
         "friendsofphp/proxy-manager-lts": "^1.0.6",
         "monolog/monolog": "*",
         "phpunit/phpunit": "^9.5.28 || ^10",
-        "predis/predis": "^2.0 || ^3.0 ",
+        "predis/predis": "^2.0 || ^3.0",
         "seec/phpunit-consecutive-params": "^1.1.4",
-        "symfony/browser-kit": "^5.4.20 ||^6.0 || ^7.0",
-        "symfony/cache": "^5.4.20 ||^6.0 || ^7.0",
-        "symfony/config": "^5.4.20 ||^6.0 || ^7.0",
-        "symfony/console": "^5.4.20 ||^6.0 || ^7.0",
-        "symfony/dom-crawler": "^5.4.20 ||^6.0 || ^7.0",
-        "symfony/filesystem": "^5.4.20 ||^6.0 || ^7.0",
-        "symfony/stopwatch": "^5.4.20 ||^6.0 || ^7.0",
-        "symfony/twig-bundle": "^5.4.20 ||^6.0 || ^7.0",
-        "symfony/web-profiler-bundle": "^5.4.20 ||^6.0 || ^7.0",
-        "symfony/yaml": "^5.4.20 ||^6.0 || ^7.0",
-        "vimeo/psalm": "^5|^6"
+        "symfony/browser-kit": "^5.4.20 || ^6.0 || ^7.0",
+        "symfony/cache": "^5.4.20 || ^6.0 || ^7.0",
+        "symfony/config": "^5.4.20 || ^6.0 || ^7.0",
+        "symfony/console": "^5.4.20 || ^6.0 || ^7.0",
+        "symfony/dom-crawler": "^5.4.20 || ^6.0 || ^7.0",
+        "symfony/filesystem": "^5.4.20 || ^6.0 || ^7.0",
+        "symfony/stopwatch": "^5.4.20 || ^6.0 || ^7.0",
+        "symfony/twig-bundle": "^5.4.20 || ^6.0 || ^7.0",
+        "symfony/web-profiler-bundle": "^5.4.20 || ^6.0 || ^7.0",
+        "symfony/yaml": "^5.4.20 || ^6.0 || ^7.0",
+        "vimeo/psalm": "^5 || ^6"
     },
     "suggest": {
         "monolog/monolog": "If you want to use the monolog redis handler.",


### PR DESCRIPTION
This PR allows to run successfully 

`composer validate --strict`

And avoid all the warnings.

The important changes:

- Minimum-stability should not be in a bundle:
Bundles and libraries should be agnostic about minimum stability, as they are dependencies of other projects. Defining minimum-stability in a bundle could force consuming projects to adopt an undesired stability level, which may lead to conflicts or instability.

Composer's strict mode only allows this in projects with "type": "project", and not for "type": "symfony-bundle".