### PR TITLE
feat(ci): bump workflow versions and minor changes

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -2,29 +2,31 @@ name: "CS"
 
 on:
   push:
+    branches: [main, master]
   pull_request:
+    branches: [main, master]
 
 jobs:
   coding-standards:
     name: "Coding Standards"
-    runs-on: "ubuntu-latest"
+    runs-on: ubuntu-latest
 
     steps:
-      - name: "Checkout"
-        uses: "actions/checkout@v3"
+      - name: "Checkout code"
+        uses: actions/checkout@v4
 
-      - name: "Install PHP"
-        uses: "shivammathur/setup-php@v2"
+      - name: "Set up PHP"
+        uses: shivammathur/setup-php@v2
         with:
-          coverage: "none"
-          php-version: "7.4"
-          tools: "cs2pr"
+          php-version: '7.4'
+          coverage: none
+          tools: cs2pr
 
-      - name: "Install dependencies with Composer"
-        uses: "ramsey/composer-install@v2"
+      - name: "Install Composer dependencies"
+        uses: ramsey/composer-install@v3
         with:
-          dependency-versions: "highest"
+          dependency-versions: highest
 
       # https://github.com/doctrine/.github/issues/3
       - name: "Run PHP_CodeSniffer"
-        run: "vendor/bin/phpcs -q --no-colors --report=checkstyle | cs2pr"
+        run: vendor/bin/phpcs -q --no-colors --report=checkstyle | cs2pr

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,4 +1,3 @@
-
 name: "SA"
 
 on:
@@ -8,21 +7,34 @@ on:
 jobs:
   static-analysis-psalm:
     name: "Static Analysis with Psalm"
-    runs-on: "ubuntu-latest"
+    runs-on: ubuntu-latest
 
     steps:
       - name: "Checkout code"
-        uses: "actions/checkout@v3"
+        uses: actions/checkout@v3
 
-      - name: "Install PHP"
-        uses: "shivammathur/setup-php@v2"
+      - name: "Set up PHP"
+        uses: shivammathur/setup-php@v2
         with:
-          coverage: "none"
-          extensions: "relay"
-          php-version: "7.4"
+          php-version: '7.4'
+          extensions: relay
+          coverage: none
+          tools: composer:v2
+
+      # Uncomment this after PR https://github.com/snc/SncRedisBundle/pull/748 gets merged
+      #- name: "Validate composer.json and composer.lock"
+      #  run: composer validate --strict
 
       - name: "Install dependencies with Composer"
-        uses: "ramsey/composer-install@v2"
+        uses: ramsey/composer-install@v2
 
-      - name: "Run a static analysis with vimeo/psalm"
-        run: "vendor/bin/psalm --show-info=false --stats --output-format=github --threads=$(nproc)"
+      - name: "Cache Psalm results"
+        uses: actions/cache@v3
+        with:
+          path: .psalm/cache
+          key: ${{ runner.os }}-psalm-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-psalm-
+
+      - name: "Run static analysis with vimeo/psalm"
+        run: vendor/bin/psalm --show-info=false --stats --output-format=github --threads=$(nproc)

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /.phpcs-cache
 /.github/workflows/redis-configs/*/nodes.conf
 /.github/workflows/redis-configs/*/*.rdb
+.phpunit.cache


### PR DESCRIPTION
This PR remove double quotes where are not needed.

- Bumps actions/checkout@v3 to actions/checkout@v4

- Add cache for .psalm/cache

- Ignore .phpunit.cache

- After https://github.com/snc/SncRedisBundle/pull/748 gets merged, the composer validate strict instruction could be enabled