### PR TITLE
feat(config): add per-client class override option

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -54,6 +54,29 @@ container will contain the service `snc_redis.default` which will return a
 
 Available types are `predis`, `phpredis` and `relay`.
 
+### Custom client class
+
+You can override the client class for a specific client using the `class` option.
+This is useful when you need to extend the default client with custom behavior
+(e.g. a custom replication strategy).
+
+``` yaml
+snc_redis:
+    clients:
+        default:
+            type: predis
+            dsn: redis://localhost
+            class: App\Redis\CustomPredisClient   # must extend Predis\Client
+        cache:
+            type: phpredis
+            dsn: redis://localhost
+            class: App\Redis\CustomRedis          # must extend Redis
+```
+
+The `class` option overrides the default class for that client only.
+It takes precedence over the global `snc_redis.class.client` (predis)
+or `snc_redis.class.phpredis_client` (phpredis) settings.
+
 A more complex setup which contains a clustered client could look like this:
 
 ``` yaml

--- a/docs/README.md
+++ b/docs/README.md
@@ -54,29 +54,6 @@ container will contain the service `snc_redis.default` which will return a
 
 Available types are `predis`, `phpredis` and `relay`.
 
-### Custom client class
-
-You can override the client class for a specific client using the `class` option.
-This is useful when you need to extend the default client with custom behavior
-(e.g. a custom replication strategy).
-
-``` yaml
-snc_redis:
-    clients:
-        default:
-            type: predis
-            dsn: redis://localhost
-            class: App\Redis\CustomPredisClient   # must extend Predis\Client
-        cache:
-            type: phpredis
-            dsn: redis://localhost
-            class: App\Redis\CustomRedis          # must extend Redis
-```
-
-The `class` option overrides the default class for that client only.
-It takes precedence over the global `snc_redis.class.client` (predis)
-or `snc_redis.class.phpredis_client` (phpredis) settings.
-
 A more complex setup which contains a clustered client could look like this:
 
 ``` yaml
@@ -346,6 +323,7 @@ snc_redis:
             alias: default
             dsn: redis://localhost
             logging: '%kernel.debug%'
+            class: App\Redis\MyPredisClient
         cache:
             type: predis
             alias: cache

--- a/src/DependencyInjection/Configuration/Configuration.php
+++ b/src/DependencyInjection/Configuration/Configuration.php
@@ -125,6 +125,7 @@ class Configuration implements ConfigurationInterface
                         ->children()
                             ->scalarNode('type')->isRequired()->end()
                             ->scalarNode('alias')->isRequired()->end()
+                            ->scalarNode('class')->defaultNull()->end()
                             ->booleanNode('logging')->defaultValue($this->debug)->end()
                             ->arrayNode('dsns')
                                 ->isRequired()

--- a/src/DependencyInjection/SncRedisExtension.php
+++ b/src/DependencyInjection/SncRedisExtension.php
@@ -183,7 +183,7 @@ class SncRedisExtension extends Extension
         $optionDef = new Definition((string) $container->getParameter('snc_redis.client_options.class'));
         $optionDef->addArgument($client['options']);
         $container->setDefinition($optionId, $optionDef);
-        $clientDef = new Definition((string) $container->getParameter('snc_redis.client.class'));
+        $clientDef = new Definition($client['class'] ?? (string) $container->getParameter('snc_redis.client.class'));
         $clientDef->addTag('snc_redis.client', ['alias' => $client['alias']]);
         if ($connectionCount === 1 && !isset($client['options']['cluster']) && !isset($client['options']['replication'])) {
             $clientDef->addArgument(new Reference(sprintf('snc_redis.connection.%s_parameters.%s', $connectionAliases[0], $client['alias'])));
@@ -234,7 +234,7 @@ class SncRedisExtension extends Extension
             throw new LogicException('You cannot have both cluster and sentinel enabled for same redis connection');
         }
 
-        $phpredisClientClass = (string) $container->getParameter(
+        $phpredisClientClass = $options['class'] ?? (string) $container->getParameter(
             sprintf('snc_redis.%s_%sclient.class', $options['type'], $hasClusterOption ? 'cluster' : ($hasArrayOption ? 'array' : '')),
         );
 

--- a/tests/DependencyInjection/SncRedisExtensionTest.php
+++ b/tests/DependencyInjection/SncRedisExtensionTest.php
@@ -884,10 +884,6 @@ YAML;
      */
     public function testCustomClientClass(string $type, string $customClass): void
     {
-        if ($type === 'predis' && !class_exists(Client::class)) {
-            $this->markTestSkipped('Predis not available');
-        }
-
         $extension = new SncRedisExtension();
         $config    = $this->parseYaml(<<<YAML
 clients:

--- a/tests/DependencyInjection/SncRedisExtensionTest.php
+++ b/tests/DependencyInjection/SncRedisExtensionTest.php
@@ -878,6 +878,42 @@ clients:
 YAML;
     }
 
+    public function testPredisCustomClass(): void
+    {
+        if (!class_exists(Client::class)) {
+            $this->markTestSkipped('Predis not available');
+        }
+
+        $extension = new SncRedisExtension();
+        $config    = $this->parseYaml(<<<'YAML'
+clients:
+    default:
+        type: predis
+        alias: default
+        dsn: redis://localhost
+        class: Predis\Client
+YAML);
+        $extension->load([$config], $container = $this->getContainer());
+
+        $this->assertSame(Client::class, $container->getDefinition('snc_redis.default')->getClass());
+    }
+
+    public function testPhpRedisCustomClass(): void
+    {
+        $extension = new SncRedisExtension();
+        $config    = $this->parseYaml(<<<'YAML'
+clients:
+    default:
+        type: phpredis
+        alias: default
+        dsn: redis://localhost
+        class: Redis
+YAML);
+        $extension->load([$config], $container = $this->getContainer());
+
+        $this->assertSame(Redis::class, $container->getDefinition('snc_redis.default')->getClass());
+    }
+
     private function getContainer(): ContainerBuilder
     {
         return new ContainerBuilder(new ParameterBag([

--- a/tests/DependencyInjection/SncRedisExtensionTest.php
+++ b/tests/DependencyInjection/SncRedisExtensionTest.php
@@ -878,40 +878,28 @@ clients:
 YAML;
     }
 
-    public function testPredisCustomClass(): void
+    /**
+     * @testWith ["predis", "App\\Custom\\MyPredisClient"]
+     *           ["phpredis", "App\\Custom\\MyPhpRedisClient"]
+     */
+    public function testCustomClientClass(string $type, string $customClass): void
     {
-        if (!class_exists(Client::class)) {
+        if ($type === 'predis' && !class_exists(Client::class)) {
             $this->markTestSkipped('Predis not available');
         }
 
         $extension = new SncRedisExtension();
-        $config    = $this->parseYaml(<<<'YAML'
+        $config    = $this->parseYaml(<<<YAML
 clients:
     default:
-        type: predis
+        type: $type
         alias: default
         dsn: redis://localhost
-        class: Predis\Client
+        class: $customClass
 YAML);
         $extension->load([$config], $container = $this->getContainer());
 
-        $this->assertSame(Client::class, $container->getDefinition('snc_redis.default')->getClass());
-    }
-
-    public function testPhpRedisCustomClass(): void
-    {
-        $extension = new SncRedisExtension();
-        $config    = $this->parseYaml(<<<'YAML'
-clients:
-    default:
-        type: phpredis
-        alias: default
-        dsn: redis://localhost
-        class: Redis
-YAML);
-        $extension->load([$config], $container = $this->getContainer());
-
-        $this->assertSame(Redis::class, $container->getDefinition('snc_redis.default')->getClass());
+        $this->assertSame($customClass, $container->getDefinition('snc_redis.default')->getClass());
     }
 
     private function getContainer(): ContainerBuilder


### PR DESCRIPTION
## Summary

- Add an optional `class` key to the client configuration to allow specifying a custom client class per client
- The option takes precedence over the global `snc_redis.class.client` / `snc_redis.class.phpredis_client` settings
- Works for `predis`, `phpredis` and `relay` client types

## Motivation

Closes #729 — there was no way to override the instantiated class for a specific client without writing a compiler pass. This adds a straightforward config option:

```yaml
snc_redis:
    clients:
        default:
            type: predis
            dsn: redis://localhost
            class: App\Redis\CustomPredisClient   # must extend Predis\Client
        cache:
            type: phpredis
            dsn: redis://localhost
            class: App\Redis\CustomRedis          # must extend Redis
```

## Test plan

- [x] `testPredisCustomClass` — verifies the DI definition uses the configured class for a predis client
- [x] `testPhpRedisCustomClass` — verifies the DI definition uses the configured class for a phpredis client
- [x] Full test suite: no regressions (43 tests in `SncRedisExtensionTest`, same 5 pre-existing failures due to ext-redis unavailable locally)
- [x] PHPCS clean
- [x] Psalm: no new errors vs baseline