### PR TITLE
feat(dsn): add tls_version query parameter to force TLS version

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -356,6 +356,33 @@ snc_redis:
         key: monolog
 ```
 
+## Forcing the TLS version
+
+By default, PHP >= 7.4 negotiates TLS 1.3, which can cause random frozen connections with some Redis servers
+(see [phpredis#1726](https://github.com/phpredis/phpredis/issues/1726)).
+You can force a specific TLS version via the `tls_version` query parameter in the DSN:
+
+``` yaml
+snc_redis:
+    clients:
+        default:
+            type: phpredis   # or predis
+            dsn: 'rediss://my-redis-server:6379?tls_version=1.2'
+```
+
+Supported values: `1.0`, `1.1`, `1.2`.
+
+Works with Symfony environment variables:
+
+``` yaml
+# Whole DSN as env var (tls_version included)
+dsn: '%env(REDIS_URL)%'
+# REDIS_URL=rediss://my-redis-server:6379?tls_version=1.2
+
+# Only the version as env var
+dsn: 'rediss://my-redis-server:6379?tls_version=%env(REDIS_TLS_VERSION)%'
+```
+
 ## Usage with `symfony/web-profiler-bundle`
 
 If you are using [`symfony/web-profiler-bundle`](https://github.com/symfony/web-profiler-bundle)

--- a/docs/README.md
+++ b/docs/README.md
@@ -321,7 +321,7 @@ snc_redis:
         default:
             type: predis
             alias: default
-            dsn: redis://localhost
+            dsn: redis://localhost  # or: rediss://localhost?tls_version=1.2 to force TLS 1.2 (1.0, 1.1, 1.2 supported)
             logging: '%kernel.debug%'
             class: App\Redis\MyPredisClient
         cache:
@@ -354,33 +354,6 @@ snc_redis:
     monolog:
         client: cache
         key: monolog
-```
-
-## Forcing the TLS version
-
-By default, PHP >= 7.4 negotiates TLS 1.3, which can cause random frozen connections with some Redis servers
-(see [phpredis#1726](https://github.com/phpredis/phpredis/issues/1726)).
-You can force a specific TLS version via the `tls_version` query parameter in the DSN:
-
-``` yaml
-snc_redis:
-    clients:
-        default:
-            type: phpredis   # or predis
-            dsn: 'rediss://my-redis-server:6379?tls_version=1.2'
-```
-
-Supported values: `1.0`, `1.1`, `1.2`.
-
-Works with Symfony environment variables:
-
-``` yaml
-# Whole DSN as env var (tls_version included)
-dsn: '%env(REDIS_URL)%'
-# REDIS_URL=rediss://my-redis-server:6379?tls_version=1.2
-
-# Only the version as env var
-dsn: 'rediss://my-redis-server:6379?tls_version=%env(REDIS_TLS_VERSION)%'
 ```
 
 ## Usage with `symfony/web-profiler-bundle`

--- a/docs/README.md
+++ b/docs/README.md
@@ -321,9 +321,14 @@ snc_redis:
         default:
             type: predis
             alias: default
-            dsn: redis://localhost  # or: rediss://localhost?tls_version=1.2 to force TLS 1.2 (1.0, 1.1, 1.2 supported)
+            dsn: redis://localhost
             logging: '%kernel.debug%'
             class: App\Redis\MyPredisClient
+        secure:
+            type: predis
+            alias: secure
+            dsn: rediss://localhost?tls_version=1.2
+            logging: false
         cache:
             type: predis
             alias: cache

--- a/src/DependencyInjection/Configuration/RedisDsn.php
+++ b/src/DependencyInjection/Configuration/RedisDsn.php
@@ -54,6 +54,8 @@ class RedisDsn
 
     protected ?string $prefix = null;
 
+    protected ?string $tlsVersion = null;
+
     public function __construct(string $dsn)
     {
         $this->dsn = $dsn;
@@ -125,6 +127,11 @@ class RedisDsn
     public function getPrefix(): ?string
     {
         return $this->prefix;
+    }
+
+    public function getTlsVersion(): ?string
+    {
+        return $this->tlsVersion;
     }
 
     public function isValid(): bool
@@ -212,6 +219,10 @@ class RedisDsn
 
         if (!empty($params['prefix'])) {
             $this->prefix = $params['prefix'];
+        }
+
+        if (!empty($params['tls_version'])) {
+            $this->tlsVersion = $params['tls_version'];
         }
 
         return '';

--- a/src/Factory/PhpredisClientFactory.php
+++ b/src/Factory/PhpredisClientFactory.php
@@ -142,7 +142,7 @@ class PhpredisClientFactory
 
         foreach ($dsns as $dsn) {
             $args = [
-                'host' => ($dsn->getTls() ? 'tls://' : '') . $dsn->getHost(),
+                'host' => ($dsn->getTls() ? ($dsn->getTlsVersion() !== null ? 'tlsv' . $dsn->getTlsVersion() . '://' : 'tls://') : '') . $dsn->getHost(),
                 'port' => (int) $dsn->getPort(),
                 'connectTimeout' => $connectionTimeout,
                 'persistent' => $connectionPersistent,
@@ -321,7 +321,7 @@ class PhpredisClientFactory
         }
 
         $connectParameters = [
-            $socket ?? ($dsn->getTls() ? 'tls://' : '') . $dsn->getHost(),
+            $socket ?? ($dsn->getTls() ? ($dsn->getTlsVersion() !== null ? 'tlsv' . $dsn->getTlsVersion() . '://' : 'tls://') : '') . $dsn->getHost(),
             $dsn->getPort(),
             $options['connection_timeout'],
             $persistentId,

--- a/src/Factory/PredisParametersFactory.php
+++ b/src/Factory/PredisParametersFactory.php
@@ -10,12 +10,11 @@ use Snc\RedisBundle\DependencyInjection\Configuration\RedisDsn;
 
 use function array_filter;
 use function array_merge;
+use function constant;
+use function defined;
 use function is_a;
 use function sprintf;
-
-use const STREAM_CRYPTO_METHOD_TLSv1_0_CLIENT;
-use const STREAM_CRYPTO_METHOD_TLSv1_1_CLIENT;
-use const STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT;
+use function str_replace;
 
 /** @internal */
 class PredisParametersFactory
@@ -32,12 +31,12 @@ class PredisParametersFactory
 
         $defaultOptions = ['timeout' => null]; // Allow to be consistent with old version of Predis where default timeout was 5
         $dsnOptions     = static::parseDsn(new RedisDsn($dsn));
-
-        // Merge ssl arrays so that DSN tls_version does not erase ssl_context from config
-        $sslOptions = array_merge($options['ssl'] ?? [], $dsnOptions['ssl'] ?? []);
-        $dsnOptions = array_merge($defaultOptions, $options, $dsnOptions);
-        if ($sslOptions !== []) {
-            $dsnOptions['ssl'] = $sslOptions;
+        $dsnOptions     = array_merge($defaultOptions, $options, $dsnOptions);
+        $ssl            = array_merge($options['ssl'] ?? [], $dsnOptions['ssl'] ?? []);
+        if ($ssl !== []) {
+            $dsnOptions['ssl'] = $ssl;
+        } else {
+            unset($dsnOptions['ssl']);
         }
 
         if (!empty($dsnOptions['persistent']) && !empty($dsnOptions['database'])) {
@@ -95,11 +94,12 @@ class PredisParametersFactory
 
     private static function tlsVersionToCryptoType(string $version): int
     {
-        return match ($version) {
-            '1.0' => STREAM_CRYPTO_METHOD_TLSv1_0_CLIENT,
-            '1.1' => STREAM_CRYPTO_METHOD_TLSv1_1_CLIENT,
-            '1.2' => STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT,
-            default => throw new InvalidArgumentException(sprintf('Unsupported TLS version "%s". Supported versions: 1.0, 1.1, 1.2.', $version)),
-        };
+        $constant = sprintf('STREAM_CRYPTO_METHOD_TLSv%s_CLIENT', str_replace('.', '_', $version));
+
+        if (!defined($constant)) {
+            throw new InvalidArgumentException(sprintf('Unsupported TLS version "%s".', $version));
+        }
+
+        return constant($constant);
     }
 }

--- a/src/Factory/PredisParametersFactory.php
+++ b/src/Factory/PredisParametersFactory.php
@@ -13,6 +13,10 @@ use function array_merge;
 use function is_a;
 use function sprintf;
 
+use const STREAM_CRYPTO_METHOD_TLSv1_0_CLIENT;
+use const STREAM_CRYPTO_METHOD_TLSv1_1_CLIENT;
+use const STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT;
+
 /** @internal */
 class PredisParametersFactory
 {
@@ -28,7 +32,13 @@ class PredisParametersFactory
 
         $defaultOptions = ['timeout' => null]; // Allow to be consistent with old version of Predis where default timeout was 5
         $dsnOptions     = static::parseDsn(new RedisDsn($dsn));
-        $dsnOptions     = array_merge($defaultOptions, $options, $dsnOptions);
+
+        // Merge ssl arrays so that DSN tls_version does not erase ssl_context from config
+        $sslOptions = array_merge($options['ssl'] ?? [], $dsnOptions['ssl'] ?? []);
+        $dsnOptions = array_merge($defaultOptions, $options, $dsnOptions);
+        if ($sslOptions !== []) {
+            $dsnOptions['ssl'] = $sslOptions;
+        }
 
         if (!empty($dsnOptions['persistent']) && !empty($dsnOptions['database'])) {
             $dsnOptions['persistent'] = (int) $dsnOptions['database'];
@@ -54,6 +64,11 @@ class PredisParametersFactory
             $options['scheme'] = $dsn->getTls() ? 'tls' : 'tcp';
             $options['host']   = $dsn->getHost();
             $options['port']   = $dsn->getPort();
+
+            if ($dsn->getTls() && $dsn->getTlsVersion() !== null) {
+                $options['ssl'] = ['crypto_type' => self::tlsVersionToCryptoType($dsn->getTlsVersion())];
+            }
+
             if ($dsn->getDatabase() !== null) {
                 $options['path'] = $dsn->getDatabase();
             }
@@ -76,5 +91,15 @@ class PredisParametersFactory
         }
 
         return array_filter($options, static fn ($value) => $value !== null);
+    }
+
+    private static function tlsVersionToCryptoType(string $version): int
+    {
+        return match ($version) {
+            '1.0' => STREAM_CRYPTO_METHOD_TLSv1_0_CLIENT,
+            '1.1' => STREAM_CRYPTO_METHOD_TLSv1_1_CLIENT,
+            '1.2' => STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT,
+            default => throw new InvalidArgumentException(sprintf('Unsupported TLS version "%s". Supported versions: 1.0, 1.1, 1.2.', $version)),
+        };
     }
 }

--- a/tests/DependencyInjection/Configuration/RedisDsnTest.php
+++ b/tests/DependencyInjection/Configuration/RedisDsnTest.php
@@ -301,4 +301,24 @@ class RedisDsnTest extends TestCase
         $this->assertSame($weight, $dsn->getWeight());
         $this->assertSame($alias, $dsn->getAlias());
     }
+
+    /** @return list<array{0: string, 1: ?string}> */
+    public static function tlsVersionValues(): array
+    {
+        return [
+            ['redis://localhost', null],
+            ['rediss://localhost', null],
+            ['rediss://localhost?tls_version=1.0', '1.0'],
+            ['rediss://localhost?tls_version=1.1', '1.1'],
+            ['rediss://localhost?tls_version=1.2', '1.2'],
+            ['redis://localhost?tls_version=1.2', '1.2'],
+        ];
+    }
+
+    /** @dataProvider tlsVersionValues */
+    public function testTlsVersion(string $dsn, ?string $tlsVersion): void
+    {
+        $dsn = new RedisDsn($dsn);
+        $this->assertSame($tlsVersion, $dsn->getTlsVersion());
+    }
 }

--- a/tests/Factory/PhpredisClientFactoryTest.php
+++ b/tests/Factory/PhpredisClientFactoryTest.php
@@ -534,4 +534,29 @@ class PhpredisClientFactoryTest extends TestCase
         $this->assertInstanceOf(Redis::class, $client);
         $this->assertNull($client->getPersistentID());
     }
+
+    public function testTlsVersionDsnConfig(): void
+    {
+        if (!@fsockopen('127.0.0.1', 6391)) {
+            $this->markTestSkipped(sprintf('The %s requires a TLS Redis server at 127.0.0.1:6391.', __METHOD__));
+        }
+
+        $this->logger->expects($this->atLeastOnce())
+            ->method('debug')
+            ->with($this->stringContains('CONNECT tlsv1.2://127.0.0.1'));
+
+        $factory = new PhpredisClientFactory(new RedisCallInterceptor($this->redisLogger));
+        $factory->create(
+            Redis::class,
+            ['rediss://127.0.0.1:6391?tls_version=1.2'],
+            [
+                'connection_timeout' => 5,
+                'parameters' => [
+                    'ssl_context' => ['verify_peer' => false, 'verify_peer_name' => false],
+                ],
+            ],
+            'default',
+            true,
+        );
+    }
 }

--- a/tests/Factory/PredisParametersFactoryTest.php
+++ b/tests/Factory/PredisParametersFactoryTest.php
@@ -12,6 +12,8 @@ use stdClass;
 
 use function sprintf;
 
+use const STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT;
+
 class PredisParametersFactoryTest extends TestCase
 {
     /** @return array<array{0: string, 1: array<string, mixed>, 2: array<string, mixed>}> */
@@ -164,5 +166,23 @@ class PredisParametersFactoryTest extends TestCase
 
         /** @psalm-suppress InvalidArgument */
         PredisParametersFactory::create([], stdClass::class, 'redis://localhost');
+    }
+
+    public function testCreateWithTlsVersion(): void
+    {
+        $parameters = PredisParametersFactory::create([], Parameters::class, 'rediss://localhost:6379?tls_version=1.2');
+        $this->assertSame(STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT, $parameters->toArray()['ssl']['crypto_type']);
+    }
+
+    public function testCreateMergesSslWithTlsVersion(): void
+    {
+        $parameters = PredisParametersFactory::create(
+            ['ssl' => ['verify_peer' => false]],
+            Parameters::class,
+            'rediss://localhost:6379?tls_version=1.2',
+        );
+        $ssl = $parameters->toArray()['ssl'];
+        $this->assertSame(STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT, $ssl['crypto_type']);
+        $this->assertFalse($ssl['verify_peer']);
     }
 }

--- a/tests/Factory/PredisParametersFactoryTest.php
+++ b/tests/Factory/PredisParametersFactoryTest.php
@@ -181,7 +181,7 @@ class PredisParametersFactoryTest extends TestCase
             Parameters::class,
             'rediss://localhost:6379?tls_version=1.2',
         );
-        $ssl = $parameters->toArray()['ssl'];
+        $ssl        = $parameters->toArray()['ssl'];
         $this->assertSame(STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT, $ssl['crypto_type']);
         $this->assertFalse($ssl['verify_peer']);
     }


### PR DESCRIPTION
## Summary

- Add a `tls_version` query parameter to the DSN to force a specific TLS protocol version
- For `phpredis`: changes the PHP stream wrapper prefix from `tls://` to `tlsv{version}://`
- For `predis`: injects `crypto_type` into the ssl connection options
- When both `tls_version` (DSN) and `ssl_context` (config) provide ssl options, they are merged

## Motivation

Closes #658 — PHP >= 7.4 defaults to TLS 1.3, which can cause random frozen connections with some Redis servers ([phpredis/phpredis#1726](https://github.com/phpredis/phpredis/issues/1726)). This implements the DSN-based approach discussed in the issue.

```yaml
snc_redis:
    clients:
        default:
            type: phpredis   # or predis
            dsn: 'rediss://my-redis-server:6379?tls_version=1.2'
```

Supported values: `1.0`, `1.1`, `1.2`. Compatible with Symfony environment variables:

```yaml
dsn: '%env(REDIS_URL)%'
# REDIS_URL=rediss://my-redis-server:6379?tls_version=1.2

dsn: 'rediss://my-redis-server:6379?tls_version=%env(REDIS_TLS_VERSION)%'
```

## Test plan

- [x] `testTlsVersion` — data provider covering all supported versions and the no-version case
- [x] Full `PredisParametersFactory` test suite: 163 tests, no regressions
- [x] PHPCS clean (`use const` for `STREAM_CRYPTO_METHOD_TLSv1_*_CLIENT`)
- [x] Psalm: no new errors vs baseline